### PR TITLE
feat: add stelvio docs to context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/stelviodev/stelvio",
+  "public_key": "pk_vAY4KH7WJTeTEDW2ws3hS"
+}


### PR DESCRIPTION
This is needed to add stelvio's docs to [context7](https://context7.com/)