### PR TITLE
fix: honor dns=False to opt out of dns management on email component

### DIFF
--- a/docs/docs/components/aws/email.md
+++ b/docs/docs/components/aws/email.md
@@ -85,7 +85,7 @@ When using a domain identity, Stelvio automatically handles:
 *   DKIM (DomainKeys Identified Mail) records
 *   DMARC (Domain-based Message Authentication, Reporting, and Conformance) records
 
-Note that for domain identities, you must have a DNS provider configured in your Stelvio app context, or pass one explicitly to the `Email` component.
+Note that for domain identities, you must have a DNS provider configured in your Stelvio app context, or pass one explicitly to the `Email` component. If you want to manage DNS yourself (see [DNS Configuration](#dns-configuration) below), pass `dns=False`.
 
 ### DMARC Configuration
 
@@ -108,6 +108,47 @@ The `dmarc` parameter is only valid for domain identities and accepts the follow
     # Disable DMARC
     email = Email("myEmail", "example.com", dmarc=False)
 ```
+
+### DNS Configuration
+
+The `dns` parameter controls how Stelvio manages DNS records for domain identities:
+
+| Value          | Behavior |
+|----------------|----------|
+| `None`         | Uses the DNS provider configured in `StelvioAppConfig`. Raises if none is configured. |
+| `Dns` instance | Uses the given provider for this Email only. Useful when the email sender domain lives on a different DNS provider than your app's main domain. |
+| `False`        | Opts out of Stelvio managing DNS for this email entirely. |
+
+When you pass `dns=False`, Stelvio still creates the SES email identity, configuration set, and any event destinations. It skips DKIM record creation, DMARC record creation, and the domain verification resource (which would otherwise block deploy waiting on records that don't exist).
+
+Use this when:
+
+* Your DNS provider isn't supported by Stelvio.
+* DKIM/DMARC records already exist for the domain from a previous setup.
+* DNS is managed by a separate team or system.
+
+!!! warning "SES won't verify the domain until DKIM records exist in DNS"
+    Stelvio's deploy completes successfully with `dns=False`, but emails won't send until you add the required DNS records yourself.
+
+After deploy, retrieve the DKIM tokens from the AWS Console (SES → Verified Identities → your domain), or expose them as Pulumi stack outputs:
+
+```python
+from stelvio import export_output
+from stelvio.aws.email import Email
+
+email = Email("alerts", "example.com", dns=False)
+export_output("alerts_dkim", email.resources.identity.dkim_signing_attributes)
+```
+
+Run `stlv outputs` after deploy to see the three DKIM tokens, then add three CNAME records to your DNS provider:
+
+```
+<token1>._domainkey.example.com  CNAME  <token1>.dkim.amazonses.com
+<token2>._domainkey.example.com  CNAME  <token2>.dkim.amazonses.com
+<token3>._domainkey.example.com  CNAME  <token3>.dkim.amazonses.com
+```
+
+Optionally add a DMARC TXT record at `_dmarc.example.com`. SES will verify the domain (usually within minutes) and emails can send.
 
 ## Sandbox Mode
 

--- a/stelvio/aws/email.py
+++ b/stelvio/aws/email.py
@@ -98,19 +98,25 @@ class Email(Component[EmailResources, EmailCustomizationDict], LinkableMixin):
         self._config = self._parse_config(config, opts)
         self.is_domain = "@" not in self.config.sender
         # We allow passing in a DNS provider since email verification may
-        # need another DNS provider than the one in context
-        if not self.config.dns:
+        # need another DNS provider than the one in context. Pass dns=False
+        # to opt out of Stelvio managing DNS records for this email entirely
+        # (DKIM, DMARC and domain verification are skipped — you handle them).
+        dns_opted_out = self.config.dns is False
+
+        if dns_opted_out:
+            self.dns = None
+        elif self.config.dns is None:
             self.dns = context().dns
         else:
             self.dns = self.config.dns
 
         if self.config.dmarc and not self.is_domain:
             raise ValueError("DMARC can only be set for domain email identities.")
-        if self.config.dmarc and not self.dns:
+        if self.config.dmarc and not self.dns and not dns_opted_out:
             raise DnsProviderNotConfiguredError(
                 "DNS provider must be configured to set DMARC records."
             )
-        if self.is_domain and not self.dns:
+        if self.is_domain and not self.dns and not dns_opted_out:
             raise DnsProviderNotConfiguredError(
                 "DNS provider must be configured to create domain email identity."
             )
@@ -157,8 +163,14 @@ class Email(Component[EmailResources, EmailCustomizationDict], LinkableMixin):
         elif isinstance(config, str):
             opts["sender"] = config
             config = EmailConfig(**opts)
-        # First apply default DMARC for domains if dmarc is None (but not explicitly False)
-        if config.dmarc is None and config.sender and "@" not in config.sender:
+        # First apply default DMARC for domains if dmarc is None (but not explicitly False).
+        # Skip default if user opted out of DNS — we can't create the DMARC record anyway.
+        if (
+            config.dmarc is None
+            and config.sender
+            and "@" not in config.sender
+            and config.dns is not False
+        ):
             config = EmailConfig(
                 sender=config.sender,
                 dmarc="v=DMARC1; p=none;",
@@ -221,7 +233,7 @@ class Email(Component[EmailResources, EmailCustomizationDict], LinkableMixin):
         dkim_records = None
         dmarc_record = None
         verification = None
-        if self.is_domain:
+        if self.is_domain and self.dns:
             dkim_records = []
             # SES always returns 3 tokens
             for i in range(3):

--- a/tests/aws/email/test_email.py
+++ b/tests/aws/email/test_email.py
@@ -593,3 +593,32 @@ def test_email_dmarc_none_for_email_identity():
     email = Email("test-email-dmarc", "user@example.com", dmarc=None)
     # Email identities don't have DMARC
     assert email.dmarc is None
+
+
+def test_email_dns_false_allows_domain_without_dns():
+    email = Email("test-no-dns", "example.com", dns=False)
+    assert email.is_domain is True
+    assert email.dns is None
+
+
+def test_email_dns_false_skips_default_dmarc():
+    email = Email("test-no-dns", "example.com", dns=False)
+    assert email.dmarc is None
+
+
+def test_email_dns_false_with_explicit_dmarc_does_not_raise():
+    email = Email("test-no-dns", "example.com", dmarc="v=DMARC1; p=reject;", dns=False)
+    assert email.dmarc == "v=DMARC1; p=reject;"
+    assert email.dns is None
+
+
+@pulumi.runtime.test
+def test_email_dns_false_skips_dkim_dmarc_verification(pulumi_mocks):
+    email = Email("test-no-dns", "example.com", dns=False)
+    resources = email.resources
+
+    assert resources.identity is not None
+    assert resources.configuration_set is not None
+    assert resources.dkim_records is None
+    assert resources.dmarc_record is None
+    assert resources.verification is None

--- a/tests/integration/test_email.py
+++ b/tests/integration/test_email.py
@@ -64,3 +64,31 @@ def test_email_configuration_set(stelvio_env):
 
     # Configuration set name follows pattern: {name}-config-set
     assert_ses_configuration_set("mailer-config-set")
+
+
+def test_email_domain_identity_dns_opted_out(stelvio_env):
+    """dns=False deploys a domain identity without a DNS provider.
+
+    The SES identity is created in pending state — user is responsible
+    for adding DKIM records to DNS externally.
+    """
+    domain = "manual-dns-integ.example.com"
+
+    def infra():
+        email = Email("manual-dns", domain, dns=False)
+        export_email(email)
+
+    outputs = stelvio_env.deploy(infra)
+
+    # SES identity exists (unverified — we never added DKIM records)
+    assert_ses_identity(domain, identity_type="DOMAIN")
+
+    # Only identity + config set ARNs exported
+    assert outputs["email_manual-dns_ses_identity_arn"]
+    assert outputs["email_manual-dns_ses_configuration_set_arn"]
+
+    # No DKIM, DMARC, or verification resources created
+    for i in range(3):
+        assert f"email_manual-dns_dkim_record_{i}_name" not in outputs
+    assert "email_manual-dns_dmarc_record_name" not in outputs
+    assert "email_manual-dns_ses_domain_verification_token_arn" not in outputs


### PR DESCRIPTION
Email component has dns config parameter and it allows `Dns | Literal[False] | None = None`. But code had a bug where False was treated same as None:
```py
if not self.config.dns:
    self.dns = context().dns
else:
    self.dns = self.config.dns
```
This PR fixes that. If user sets dns explicitly to `False` we skip it also with dmarc, dkim etc and user is responsible of updating dns records himself. This I assume was original intention of the `False` value, otherwise it doesn't make much sense.