### PR TITLE
test: trim redundant hit assertions in TestReadableType

### DIFF
--- a/tests/test_rich_deployment_handler.py
+++ b/tests/test_rich_deployment_handler.py
@@ -850,9 +850,6 @@ class TestNestedComponentParentResolution:
 class TestReadableType:
     def test_known_types(self):
         assert _readable_type("aws:lambda/function:Function") == "Lambda Function"
-        assert _readable_type("aws:iam/role:Role") == "IAM Role"
-        assert _readable_type("aws:dynamodb/table:Table") == "DynamoDB Table"
-        assert _readable_type("aws:s3/bucketV2:BucketV2") == "S3 Bucket"
 
     def test_unknown_type_falls_back(self):
         assert _readable_type("aws:custom/thing:Thing") == "aws:custom/thing:Thing"


### PR DESCRIPTION
All 4 asserts hit the same dict lookup, so 3 were just noise,  kept one plus the fallback test. A wrong token string can only be caught by a test that renders a real deployment; that's out of scope here.