### PR TITLE
docs: contributor guides for components, tests and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,15 @@ Key areas of the codebase:
 
 ## Development
 
+### Writing code and docs
+
+The contributor guides on stelvio.dev cover the patterns we follow:
+
+- [Writing components](https://stelvio.dev/docs/contributing/components/)
+- [Writing unit tests](https://stelvio.dev/docs/contributing/unit-tests/)
+- [Writing integration tests](https://stelvio.dev/docs/contributing/integration-tests/)
+- [Writing documentation](https://stelvio.dev/docs/contributing/docs/)
+
 ### Tests
 
 Stelvio has unit tests and integration tests.
@@ -51,24 +60,15 @@ uv run pytest                  # run all unit tests
 uv run pytest --cov            # with coverage
 ```
 
-**Integration tests** deploy real AWS resources. Most contributors won't need to run these — unit tests are sufficient for the majority of changes. Integration tests are primarily for verifying infrastructure behavior and are split into two tiers:
+**Integration tests** deploy real AWS resources, assert against them with boto3, then destroy them. They're the release gate: if you add or change infrastructure behavior, add or update integration tests too (see [Writing integration tests](https://stelvio.dev/docs/contributing/integration-tests/)). Running them is a separate question — they need an AWS account and take minutes, and CI runs them only on manual dispatch. Run them if you can; say so in your PR if you can't.
 
-*Standard tier* — tests core components (DynamoDB, Lambda, SQS, SNS, S3, API Gateway, CloudFront, etc.). Requires an AWS profile with permissions to create these resources:
-
-```bash
-STLV_TEST_AWS_PROFILE=<profile> uv run pytest tests/integration/ --integration -v -n 8
-```
-
-*DNS tier* — tests that need a Route 53 hosted zone for DNS validation (ACM certificates, CloudFront custom domains, SES domain identities). Slower due to DNS/certificate propagation:
+There are three tiers — standard, CloudFront (slow teardown), and DNS (needs a Route 53 hosted zone). `tests/integration/run_all.sh` is the single source of truth for tiers and worker counts and runs them all in parallel:
 
 ```bash
-STLV_TEST_AWS_PROFILE=<profile> \
-  STLV_TEST_DNS_DOMAIN=<domain> \
-  STLV_TEST_DNS_ZONE_ID=<zone-id> \
-  uv run pytest tests/integration/test_dns_*.py --integration-dns -v -n 3
+STLV_TEST_AWS_PROFILE=<profile> ./tests/integration/run_all.sh
 ```
 
-Both tiers run in parallel. Use `-k` to filter by component, e.g. `pytest -k "dynamo"`.
+The DNS tier runs only when `STLV_TEST_DNS_DOMAIN` and `STLV_TEST_DNS_ZONE_ID` are also set. To run a single tier or component, take the pytest command for that tier from `run_all.sh`; use `-k` to filter by component, e.g. `-k "dynamo"`.
 
 ### Linting and formatting
 

--- a/docs/docs/contributing/components.md
+++ b/docs/docs/contributing/components.md
@@ -1,0 +1,181 @@
+# Writing components
+
+A component wraps a group of AWS resources behind one Python class. Users construct it, link
+it, read `.resources`. Three files are worth reading next to this page:
+
+- `stelvio/aws/cron.py`: the shape to copy. Validation, handler parsing, a wrapped Function.
+- `stelvio/aws/topic.py`: linking, properties, child components.
+- `stelvio/aws/vpc.py`: many resources, per-resource customization and tags.
+
+## In Pulumi terms
+
+`Component` extends Pulumi's `ComponentResource`. The type string passed to
+`super().__init__`, `"stelvio:aws:Cron"`, becomes its URN type, and everything created with
+`self._resource_opts()` is parented under it in state:
+
+```
+stelvio:aws:Cron (nightly-report)
+├── aws:cloudwatch/eventRule:EventRule
+├── aws:cloudwatch/eventTarget:EventTarget
+├── aws:lambda/permission:Permission
+└── stelvio:aws:Function (nightly-report-fn)
+    ├── aws:iam/role:Role
+    ├── aws:iam/rolePolicyAttachment:RolePolicyAttachment
+    └── aws:lambda/function:Function
+```
+
+This tree is what the CLI groups deploy output by. `_resource_opts()` also adds an alias
+from the stack root, so apps deployed before a resource moved into a component migrate
+without replacement.
+
+## The shape
+
+Two halves. `__init__` validates and stores, `_create_resources()` creates and returns.
+The component registers itself with Pulumi on construction; the AWS resources don't exist
+until Stelvio reads `.resources` at deploy time.
+
+```python
+class Cron(Component[CronResources, CronCustomizationDict]):
+    def __init__(self, name, schedule, ..., *, tags=None, customize=None):
+        super().__init__("stelvio:aws:Cron", name, tags=tags, customize=customize)
+        _validate_schedule(schedule)
+        self._schedule = schedule
+
+    def _create_resources(self) -> CronResources:
+        rule = cloudwatch.EventRule(...)
+        ...
+        return CronResources(rule=rule, target=target, permission=permission, function=fn)
+```
+
+The rules:
+
+- Validate in `__init__` with module-level pure functions. Raise `ValueError` or `TypeError`
+  naming the bad value and the accepted shapes. Fail when the object is constructed, not
+  halfway through a deploy; what needs a cloud lookup (Vpc's AZ check) is the exception.
+- `_create_resources()` is pure: reads `self._x`, sets nothing, returns everything.
+- Resources land in a frozen `@final` dataclass named `{Component}Resources`. Expose what a
+  user might reference; machinery (route table associations) stays out.
+- Every component's `__init__` must have keyword-only `customize`, plus `tags` unless
+  nothing it creates supports tags on AWS (`TopicQueueSubscription`), and `parent` when
+  other components use it (like `Function`). Mark the class `@final`.
+
+## The four dataclasses
+
+A component brings up to four supporting types, named by convention:
+
+- `{X}Resources`: what `_create_resources()` returns. Always.
+- `{X}CustomizationDict`: the valid `customize=` keys, one per resource. Mirrors
+  `{X}Resources` fields (singular where those are lists); a shared test keeps them in sync.
+- `{X}Config` and `{X}ConfigDict`: when a component takes too many extra params. The
+  constructor already carries `name`, `tags`, `customize`; two or three extras are the max
+  (Cron's `schedule`, `enabled`, `payload`), over that, group them into a dataclass with a
+  plain-dict twin (`NatConfig`, `DynamoTableConfig`). Validate in `__post_init__`, normalize
+  dict-or-dataclass once in `__init__`, so the rest of the code sees one type. Keep the twins
+  in sync with `assert_config_dict_matches_dataclass` in the component's tests.
+
+They live in the component's file; `function/` splits into modules only because of size.
+
+## Child resources
+
+Every Pulumi resource gets `opts=self._resource_opts()`: parent, provider, and migration
+alias in one place. `depends_on` goes through it too. Don't build `ResourceOptions` by hand.
+
+Child Stelvio components (a wrapped `Function`) instead take `parent=self`, `tags=self.tags`,
+and their slice of customization: `customize=self._customize.get("function")`.
+
+Components are the user-facing units; Pulumi resources are the machinery Stelvio runs for
+you. Vpc's `Route` and `RouteTableAssociation` are machinery, so they stay hidden, not even
+in `VpcResources`. `TopicSubscription` is a component for an architectural reason: at deploy
+Stelvio creates every registered component's resources independently, so each subscription
+is its own unit. Its `Function`, subscription and permission come up on their own;
+`Topic._create_resources()` never knows how many subscriptions exist. Own unit also means
+own customization, tags, and group in deploy output.
+
+## Customization and tags
+
+Every resource's args go through the customizer:
+
+```python
+rule = cloudwatch.EventRule(
+    rule_name,
+    **self._customizer("rule", {"schedule_expression": self._schedule}, inject_tags=True),
+    opts=self._resource_opts(),
+)
+```
+
+Declare the keys in a `CustomizationDict` TypedDict (the second type parameter); the base
+class validates them. Merge is shallow, the user's value replaces yours. `inject_tags=True`
+on taggable resources only, and keep it at the callsite where you can see it.
+
+## Naming
+
+Before naming a resource, know where the string ends up. Three destinations:
+
+1. **Pulumi state**: the logical name, the resource's first constructor arg. Always exists,
+   no limit to worry about.
+2. **AWS physical name**, if the resource has one, in one of two ways. Don't set the
+   resource's `name` arg and Pulumi derives it from the logical name plus a random suffix.
+   Set `name=` yourself and the string goes to AWS exactly as is (Topic does, because FIFO
+   names must end in `.fifo`).
+3. **The `Name` tag**: some resources (VPC, subnets, gateways) have no AWS name at all. The
+   human-readable name is a tag, and tag values cap at 256.
+
+`safe_name(prefix, name, max_length, suffix, pulumi_suffix_length)` builds the string for
+all of these: app-env prefix plus your name, and when that would blow `max_length` it
+truncates the name's tail and stamps a 7-char hash to keep it unique. Pick params from the
+destination:
+
+- `max_length`: the limit where the string lands. The AWS name limit for the resource type
+  (64 for EventBridge rules, 256 for SNS topics), or 256 when it only lands in a tag.
+- `pulumi_suffix_length`: 8 (default) when Pulumi will append its random suffix, meaning
+  the resource has an AWS name you didn't set explicitly. 0 otherwise.
+- `suffix`: anything that must survive truncation intact; it's re-appended after the hash.
+  `.fifo` is the case that forced the param.
+
+Repeated `safe_name` calls with the same params are worth a local helper (Vpc's
+`_safe_name`). DRY applies here like everywhere.
+
+## Linking
+
+If other components will link to yours, add `LinkableMixin` and a default creator:
+
+```python
+@link_config_creator(Topic)
+def default_topic_link(topic: Topic) -> LinkConfig:
+    t = topic.resources.topic
+    return LinkConfig(
+        properties={"topic_arn": t.arn, "topic_name": t.name},
+        permissions=[AwsPermission(actions=["sns:Publish"], resources=[t.arn])],
+    )
+```
+
+Properties become `STLV_` env vars on the linked Function, and typed accessors in the
+`stlv_resources.py` Stelvio generates into its Lambda package. Permissions become IAM
+statements on its role. Least privilege: the actions a user of the component needs, not
+`sns:*`. Not everything links; Vpc has no creator because there's nothing to call and
+nothing to permit.
+
+## Public surface
+
+Two kinds of properties belong on the class:
+
+- Shortcuts to resource outputs users wire elsewhere: `topic.arn` is
+  `self.resources.topic.arn`. Same for `url`, `stream_arn`, names.
+- The parsed config, as one `config` property (DynamoTable), not a mirror property per
+  field. A field shortcut like `partition_key` only when it earns its traffic.
+
+`self.register_outputs({...})` keys show in the CLI after deploy. The bar is high: so far
+only URLs, `{"url": url}`, the one thing a user goes looking for. Most components skip the
+call.
+
+## Checklist
+
+Code: validation, `_create_resources`, `_resource_opts` everywhere, customization keys,
+tags, `safe_name`, link creator if linkable. Then the part that gets forgotten:
+
+- Export from the package `__init__.py`.
+- Unit tests plus the four shared suites (see [Writing unit tests](unit-tests.md)), and
+  integration tests.
+- Creates persistent data? Add its types to `_DATA_LOSS_REPLACEMENT_TYPES` in
+  `stelvio/rich_deployment_model.py` so replacements warn before eating data.
+- Docs page with a `zensical.toml` nav entry, README component list, changelog entry.

--- a/docs/docs/contributing/docs.md
+++ b/docs/docs/contributing/docs.md
@@ -1,0 +1,112 @@
+# Writing documentation
+
+Docs are how users experience Stelvio before they run it. Three pages are worth reading
+next to this page:
+
+- `docs/docs/components/aws/vpc.md`: the component guide to copy. Defaults stated up front,
+  a cost section, a warning admonition doing real work, customization with resource keys.
+- `docs/docs/components/aws/queues.md`: the configuration patterns — options table, link
+  properties and permissions tables.
+- `docs/docs/components/aws/lambda.md`: a deep feature page (packaging, dependencies,
+  layers) kept navigable by its section structure.
+
+## Where docs live
+
+Everything is under `docs/docs/`:
+
+- `intro/`: install, quickstart, CLI, project structure, troubleshooting.
+- `concepts/`: cross-component ideas — linking, environments, state, customization, tags.
+- `components/aws/`: one guide per component.
+- `contributing/`: these pages.
+
+`uv run zensical serve` builds and serves the site locally. Navigation is `[[project.nav]]`
+blocks in `zensical.toml`, one per top-level section, paths relative to `docs/`:
+
+```toml
+[[project.nav]]
+Components = [
+    { "AWS" = [
+        { "Vpc" = "docs/components/aws/vpc.md" },
+    ] },
+]
+```
+
+Because of how the website is built, only pages under `docs/docs` publish — anything
+elsewhere renders in local `zensical serve` and never reaches stelvio.dev.
+
+## The component guide shape
+
+The sections, in order, with the live example to copy:
+
+1. **Title**: "Working with X in Stelvio".
+2. **Intro**: what it is, a link to the AWS docs, and what Stelvio creates by default. If
+   it bills while idle, warn here, not in a footnote — vpc.md opens with a "NAT costs
+   money" admonition.
+3. **Creating X**: the smallest working example.
+4. **Features**: one section per parameter or feature, each leading with a code example;
+   prose explains after. Add an options table (Option | Default | Description) on top
+   when there are several flat options worth scanning (queues.md); vpc.md has none, its
+   two parameters each carry a section.
+5. **Cost**: its own section when the component bills while idle — NAT today; containers,
+   EC2, DocumentDB as they arrive. Real monthly numbers and a link to AWS pricing
+   (vpc.md). Pay-per-use serverless components skip it.
+6. **Linking**: Link Properties and Link Permissions tables (queues.md, topics.md).
+7. **Customization**: a pointer to the [customization concept page](../concepts/customization.md),
+   then a Resource Keys table — key, Pulumi Args type linked to the Pulumi registry,
+   description — and one example (vpc.md).
+8. **Next Steps**: links to the related concept pages.
+
+Concept pages are freer in form, but the same rule holds: lead with code, explain after.
+
+## Tone
+
+Explain to a smart colleague. Friendly, direct, concrete.
+
+- No marketing language ("powerful", "simple", "blazing fast"). Say what it does and what
+  it costs; readers judge for themselves.
+- Stelvio API names, not the underlying AWS, ASL, or Pulumi names: `state_timeout`, not
+  `TimeoutSeconds`. A one-time "maps to X" when introducing a parameter is fine; don't
+  re-surface it at every mention.
+- One good example beats three similar ones. If a second example doesn't show a different
+  behavior, cut it.
+- No comparisons with other frameworks.
+- What the user needs to know, not how Stelvio implements it. Internals earn a place
+  when they affect the user: lambda.md explains how packaging works because that decides
+  what ends up in the zip.
+
+## Zensical mechanics
+
+Admonitions carry detail that would break the flow of the main text — a naming rule AWS
+enforces, a cost warning, a planned feature:
+
+```markdown
+!!! warning "NAT costs money"
+    A VPC itself is free, but NAT is not — the default two-AZ setup with
+    `nat="managed"` costs about $73/month plus data charges.
+```
+
+Stick to: `info`, `warning`, `tip`, `important`, `note`.
+
+Every code block declares its language. Tables are for enumerable facts: configuration
+options, link properties, resource keys, filter syntax.
+
+One rendering footgun: a list directly after a paragraph needs a blank line before it or
+it renders as part of the paragraph.
+
+## Verify everything
+
+Every example must work against the current codebase. Before a docs PR:
+
+- Run the imports; `from stelvio.aws.vpc import Vpc, NatConfig` must be real.
+- Check every parameter, property, and method named in prose and tables exists, with the
+  documented default.
+- Placeholders look real: `functions/orders.handler`, `my-queue`, `YOUR_PROFILE_NAME` —
+  never `xxx` or `TEXT`.
+
+Stale docs teach users wrong; a missing page teaches them nothing. Wrong is worse.
+
+## Checklist
+
+For a new component, the docs work is: the guide page, its `zensical.toml` nav entry, the
+component list in `README.md`, and a changelog entry. The
+[component checklist](components.md#checklist) ends at the same place this page begins.

--- a/docs/docs/contributing/docs.md
+++ b/docs/docs/contributing/docs.md
@@ -108,5 +108,5 @@ Stale docs teach users wrong; a missing page teaches them nothing. Wrong is wors
 ## Checklist
 
 For a new component, the docs work is: the guide page, its `zensical.toml` nav entry, the
-component list in `README.md`, and a changelog entry. The
-[component checklist](components.md#checklist) ends at the same place this page begins.
+component list in `README.md`, and a changelog entry. This is the same list the
+[component checklist](components.md#checklist) ends with — that page hands off to this one.

--- a/docs/docs/contributing/integration-tests.md
+++ b/docs/docs/contributing/integration-tests.md
@@ -1,0 +1,150 @@
+# Writing integration tests
+
+Integration tests deploy real AWS resources, assert against them with boto3, then destroy
+them. They need an AWS profile and take minutes. Unit tests prove we asked AWS for what we
+intended; these prove AWS accepted it and the thing works — see
+[Writing unit tests](unit-tests.md).
+
+They're the release gate: every component has them, add them for what you add. CI runs them on
+manual dispatch only (`.github/workflows/integration-tests.yml`, Python 3.12–3.14), so nothing
+runs them on your PR. Run them yourself if you have an account; say so in the PR if you can't.
+
+Read `tests/integration/test_queue.py` and `test_scenario_events.py` next to this page.
+
+## The shape
+
+```python
+pytestmark = pytest.mark.integration
+
+
+def test_queue_subscribe(stelvio_env, project_dir):
+    def infra():
+        queue = Queue("tasks")
+        sub = queue.subscribe("processor", "handlers/echo.main", batch_size=5)
+        export_queue(queue)
+        export_function(sub.resources.function)
+
+    outputs = stelvio_env.deploy(infra)
+
+    assert_event_source_mapping(
+        outputs["function_tasks-processor_arn"],
+        event_source_arn=outputs["queue_tasks_arn"],
+        batch_size=5,
+    )
+```
+
+`stelvio_env` deploys `infra()` into its own stack and destroys it on teardown. Nothing is
+exported automatically: call the `export_*` helper from `export_helpers.py` for every resource
+you assert on, that dict is your only handle on what AWS created. Keys are
+`{component}_{name}_{field}`; check `export_helpers.py` for the exact key. `project_dir` is a
+temp project with `handlers/` copied in — needed whenever the test deploys a Function.
+
+## Asserting
+
+Assert helpers read the resource back with boto3 and take keyword-only params they check only
+when you pass them — extend an existing helper instead of writing a one-off. Most live in
+`assert_helpers.py`; that file is too big and being split, so helpers for a new component go
+in their own module like `assert_vpc.py`. Get clients from `_boto3_session()`, never build a
+session inline.
+
+A green deploy proves nothing about behavior. Invoke what you can: `invoke_lambda` for a
+Function, `http_request` for an API — that's how bundling bugs surface.
+
+Never substring-assert. Parse the structure and compare exact values:
+
+```python
+# BAD — passes on the wrong field
+assert "process-123" in json.dumps(event)
+
+# GOOD
+sqs_body = json.loads(event["Records"][0]["body"])
+assert sqs_body["task"] == "process-123"
+```
+
+## Scenario tests
+
+Property tests read configuration back. Scenario tests prove the wiring fires: deploy the
+source plus a subscriber and a results table, trigger, poll, assert the parsed event.
+
+```python
+def test_scenario_queue_triggers_lambda(stelvio_env, project_dir):
+    def infra():
+        results = DynamoTable("results", fields={"pk": "S"}, partition_key="pk")
+        queue = Queue("jobs")
+        queue.subscribe("worker", "handlers/event_recorder.main", links=[results])
+        export_dynamo_table(results)
+        export_queue(queue)
+
+    outputs = stelvio_env.deploy(infra)
+
+    send_sqs_message(outputs["queue_jobs_url"], {"task": "process-123"})
+
+    items = poll_dynamo_items(outputs["dynamotable_results_name"])
+    assert len(items) >= 1
+    event = json.loads(items[0]["event"])
+    sqs_body = json.loads(event["Records"][0]["body"])
+    assert sqs_body["task"] == "process-123"
+```
+
+Triggers: `send_sqs_message`, `publish_sns_message`, `upload_s3_object`, `put_dynamo_item`,
+`invoke_lambda`, `http_request`. Waits: `poll_dynamo_items`, `poll_sqs_messages`, `drain_sqs`,
+`wait_for_event_source_mapping`. Handlers are pre-built in `handlers/` (`echo`,
+`event_recorder`, `api_crud`, `invoker`, `queue_sender`, `auth`) — they reference link names
+like `Resources.results`, so the component name in your test has to match.
+
+## Tiers
+
+| Tier | Marker | Flag | Needs |
+|---|---|---|---|
+| Standard | `integration` | `--integration` | AWS profile |
+| CloudFront | `integration_cf` | `--integration-cf` | AWS profile |
+| DNS | `integration_dns` | `--integration-dns` | + `STLV_TEST_DNS_DOMAIN`, `STLV_TEST_DNS_ZONE_ID` |
+
+CloudFront distributions take 3–5 minutes to delete, so they get their own tier; their property
+tests skip edge propagation with `customize=NO_WAIT_DEPLOY`. DNS tests skip themselves when the
+env vars are missing. `run_all.sh` is the single source of truth for test/worker counts —
+they're picked so tests divide evenly with no straggler; update them there when you add tests.
+
+## Running them
+
+```bash
+# all tiers in parallel (DNS tier only if the domain vars are set)
+STLV_TEST_AWS_PROFILE=<profile> ./tests/integration/run_all.sh
+
+# one tier — take -n from the matching line in run_all.sh
+STLV_TEST_AWS_PROFILE=<profile> uv run pytest tests/integration/ --integration -v -n <N>
+
+# filter
+STLV_TEST_AWS_PROFILE=<profile> uv run pytest tests/integration/ --integration -k dynamo
+```
+
+Never combine tier flags in one pytest run: it opens too many files and the run collapses.
+Don't interrupt after `[100%]` — teardown is still destroying stacks. Wait for the summary
+line.
+
+A killed run leaves stacks and resources behind:
+
+```bash
+STLV_TEST_AWS_PROFILE=<profile> uv run python tests/integration/cleanup.py --tags --names
+```
+
+Default is state files in the temp dir; `--tags` scans by `stelvio:env=test`, `--names` by the
+`stlv-<hex>-test-` prefix, `--dry-run` shows without deleting, `--region` repeats for
+cross-region runs.
+
+## Cost and isolation
+
+Each test deploys into its own stack (`integ-<test-name>`) under an app named `stlv-<6 hex>`,
+so parallel runs and reruns never collide. Teardown destroys it, retries once after a refresh,
+and prints the state dir if it still fails. The resources are real: Lambda, DynamoDB, SQS and
+SNS stay near free tier, CloudFront and NAT gateways don't.
+
+## Gotchas
+
+- DynamoDB Streams: after `wait_for_event_source_mapping()` the mapping still has to discover
+  shards. Write items in a loop until one lands; write-once-then-poll times out.
+- S3 notifications: AWS sends `s3:TestEvent` when the config is created. Sleep, `drain_sqs()`,
+  then trigger.
+- A bucket that receives objects needs `customize=FORCE_DESTROY_BUCKET`, otherwise destroy
+  fails on a non-empty bucket.
+- Sleeps are named module constants with a comment explaining the number.

--- a/docs/docs/contributing/unit-tests.md
+++ b/docs/docs/contributing/unit-tests.md
@@ -1,0 +1,172 @@
+# Writing unit tests
+
+Unit tests run Pulumi with mocked providers: nothing deploys, no AWS credentials, the suite
+runs in seconds. `uv run pytest`.
+
+AWS component tests live in `tests/aws/`, core tests in `tests/` itself, plus `tests/dns/` and
+`tests/bridge/`. Integration tests (`tests/integration/`) deploy real resources and gate
+releases: every component has them, add them for anything new, run them if you can. See
+[Writing integration tests](integration-tests.md).
+
+Read `tests/aws/test_vpc.py` next to this page. It's the file the others are converging on.
+
+## Test behavior, not implementation
+
+That's Kent Beck's line and it's the whole idea. Build the component the way a user does,
+constructor and `.resources`, nothing below. Then assert what that produced. Non-component
+code follows the same rule: feed inputs at the highest practical seam, assert
+user-observable output.
+
+```python
+def test_vpc_raises_type_error_when_nat_wrong_type():
+    error = "'nat' must be 'managed', a NatConfig, a dict, or None."
+    with raises(TypeError, match=re.escape(error)):
+        Vpc("main_vpc", nat=42)
+```
+
+The check could also target the helper that does the validating:
+
+```python
+    with raises(TypeError, match=re.escape(error)):
+        _normalize_nat(42)
+```
+
+Both pass today. Only the `Vpc` one survives renaming `_normalize_nat`, inlining it, or
+moving the check into `NatConfig.__post_init__`. Same rule for config dataclasses: drive
+validation through `Vpc(nat={"type": "ec2"})`, not `NatConfig(type="ec2")`. Config objects are
+fine as inputs, not as the thing under test.
+
+What a user can see:
+
+- **Created resources**: type, inputs, how they reference each other. Including resources
+  `.resources` never exposes (`Route`, `RouteTableAssociation`): the test doesn't create
+  them and Python can't reach them, but they land in the user's AWS account. Behavior, not
+  implementation; `assert_res_counts` is what keeps them guarded.
+- **Validation errors**: exception type and message.
+- **Public surface**: `.resources` and properties like `topic.arn`, where they resolve from a
+  created resource. A property echoing config back is plumbing, skip it.
+- **Links**: `STLV_` env vars and IAM statements on a linked `Function`.
+
+Everything else is implementation. If you're reaching into `ComponentRegistry._instances`, the
+assertion you want is on a created resource.
+
+**The invariant: no behavior may be guarded only by a test that reaches below the public
+API.** When the behavioral tests are a complete net, refactors stay green. A below-API test
+whose behavior is already pinned behaviorally is redundant: delete it.
+
+Prove redundancy by mutation, not coverage. Break the behavior, run the suite, watch something
+fail, restore. If nothing fails you've found a gap (add the behavioral test) or a genuine
+exception (keep the test, say why). Coverage proves a line ran, not that anything asserted the
+result. We've had a mutation survive at 94%.
+
+Beck's [Test Desiderata](https://testdesiderata.com/) is the longer yardstick. Three of the
+twelve matter most here:
+
+- **Structure-insensitive**: what implementation-coupled tests break. The point of this page.
+- **Specific**: the price you pay. A public-API test says less about where it broke; earn it
+  back with good names and narrow assertions, not with a unit test.
+- **Predictive**: mocks return plausible values, not AWS's. Green means we asked for what we
+  intended, not that AWS accepts it. That's what integration tests are for.
+
+## Writing a test
+
+`clean_registries` and `app_context` are autouse: clean registry, app `test`, env `test`,
+region `us-east-1`. That's where the `TP` prefix (`"test-test-"`) comes from.
+
+Beyond that, take what you need. Constructor validation needs no fixtures, like the test
+above. `pulumi_mocks` when you assert on created resources, or when validation fires at deploy
+(VPC's AZ check needs the region lookup). `project_cwd` when a `Function` is involved, its
+handler file has to exist on disk.
+
+Creating Pulumi resources requires `@pulumi.runtime.test`, in one of two shapes. Decorate the
+test itself and return `Output.all(...).apply(check)` when the asserts ride on outputs of
+resources you hold:
+
+```python
+@pulumi.runtime.test
+def test_vpc_resources_parented_to_vpc_component(pulumi_mocks):
+    r = Vpc("main_vpc").resources
+
+    def check(urns):
+        for urn in urns:
+            assert "::stelvio:aws:Vpc$" in urn
+
+    return pulumi.Output.all(r.vpc.urn, r.internet_gateway.urn).apply(check)
+```
+
+Every output the check reads goes inside the `Output.all`. The check runs when the listed
+outputs resolve; one you read but didn't list may not have settled yet, and the test goes
+flaky.
+
+Decorate an inner `deploy()` when you assert on what the mocks recorded: inputs, counts, or
+resources that never reach the `Resources` dataclass (`RouteTableAssociation`, `Route`). Those
+are only complete after settlement, and `deploy()` returns after it, so the asserts are plain
+code:
+
+```python
+def test_vpc(pulumi_mocks):
+    @pulumi.runtime.test
+    def deploy():
+        return Vpc("main_vpc").resources
+
+    deploy()
+
+    pulumi_mocks.assert_res("main_vpc-igw", R.INTERNET_GATEWAY, {
+        "vpcId": tid(TP + "main_vpc"),
+        "tags": {"Name": TP + "main_vpc-igw"},
+    })
+    pulumi_mocks.assert_res_counts({
+        R.VPC: 1, R.INTERNET_GATEWAY: 1, R.SUBNET: 6,
+        R.ROUTE_TABLE: 6, R.ROUTE_TABLE_ASSOCIATION: 6,
+    })
+```
+
+## Asserting resources
+
+`assert_res(name, typ, inputs)`: exactly one resource named `TP + name`, full input compare.
+Keys are camelCase: the component passes `cidr_block`, Pulumi records `cidrBlock`, and the
+mocks hold what Pulumi recorded — assert `"cidrBlock"`. `tid(name)` is the mock's id for a resource, `R` the
+type tokens. `partial=True` compares only the keys you list; the full compare is what catches
+the input you didn't mean to send, so prefer it. JSON-string inputs compare parsed,
+`json.loads(inputs["input"]) == payload`, never string to string.
+
+`assert_res_counts` seals the test: exact counts per type, anything undeclared fails. **Assert
+all the resources, not just the ones you're testing**, otherwise everything outside your three
+assertions is unguarded. `assert_no_res(*types)` is the negative form.
+
+Older suites use `created_*` helpers returning lists you count by hand. Read them, don't write
+them.
+
+## Parametrize what varies
+
+Tests that differ only in inputs and expected values are one parametrized test:
+
+```python
+@mark.parametrize(("az", "error_message"), [
+    param(0, "When `az` is a number it must be at least 1, got 0", id="zero"),
+    param([], "When `az` is a list, you must provide at least one name.", id="empty-list"),
+])
+def test_vpc_raises_value_error_when_az_invalid(az, error_message):
+    with raises(ValueError, match=re.escape(error_message)):
+        Vpc("main_vpc", az=az)
+```
+
+Add an `id` only when the values don't read well on their own. `0` and `[]` are fine, a long
+error string isn't.
+
+Don't merge tests that only look alike, and don't add a column that repeats the input.
+Repeating test *data* is fine, it's duplicated *logic* we're removing.
+
+Three habits reviewers check: import helpers directly, `from pytest import mark, param,
+raises`. Always give `raises` a `match`, a bare `raises(ValueError)` passes on the wrong
+error. And no message on a plain `assert x == y`, pytest already prints both sides — add
+context only when the failure couldn't say which resource it was.
+
+## Shared suites
+
+A new component also registers in four cross-component suites. Reviewers check all four:
+
+- `tests/aws/test_tagging_contract.py`: `tags=` lands on every taggable resource.
+- `tests/aws/test_customization_sync.py`: customize keys stay in sync with `Resources` fields.
+- `tests/aws/test_keyword_only_constructor_params.py`: `tags` and `customize` are keyword-only.
+- `tests/test_type_urns.py`: the canonical URN list, with its count.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,24 +15,15 @@ NO_WAIT_DEPLOY = {"distribution": {"wait_for_deployment": False}}
 FORCE_DESTROY_BUCKET = {"bucket": {"force_destroy": True}}
 
 
-# Test tiers — each requires different env config or worker count.
-# Tiers run as separate pytest processes in parallel (see run_all.sh).
-# Worker counts are chosen so tests divide evenly with no straggler.
-# Adjust worker counts in run_all.sh when adding/removing tests.
+# Test tiers — each requires different env config or worker count. Tiers run as
+# separate pytest processes in parallel; run_all.sh is the canonical runner and
+# the single source of truth for test/worker counts.
 #
-#   integration     — standard tests, AWS profile only (159 tests / 10 workers)
-#     STLV_TEST_AWS_PROFILE=<profile> uv run pytest tests/integration/ --integration -v -n 10
+#   integration     — standard tests, AWS profile only
+#   integration_cf  — CloudFront/Router/S3StaticWebsite, slow teardown
+#   integration_dns — needs STLV_TEST_DNS_DOMAIN + STLV_TEST_DNS_ZONE_ID
 #
-#   integration_cf  — CloudFront/Router/S3StaticWebsite, slow teardown (13 tests / 7 workers)
-#     STLV_TEST_AWS_PROFILE=<profile> uv run pytest tests/integration/ --integration-cf -v -n 7
-#
-#   integration_dns — needs Route 53 domain + zone ID (8 tests / 4 workers)
-#     STLV_TEST_AWS_PROFILE=<profile> STLV_TEST_DNS_DOMAIN=<domain> \
-#       STLV_TEST_DNS_ZONE_ID=<zone-id> \
-#       uv run pytest tests/integration/ --integration-dns -v -n 4
-#
-# Run all tiers in parallel:
-#     tests/integration/run_all.sh
+# Run: STLV_TEST_AWS_PROFILE=<profile> tests/integration/run_all.sh
 #
 # Future tiers:
 #   cloudflare — Cloudflare DNS tests (needs Cloudflare API token + zone, slow propagation)

--- a/tests/integration/run_all.sh
+++ b/tests/integration/run_all.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Run all integration test tiers in parallel.
 #
-# Worker counts are chosen so tests divide evenly across workers with no
-# straggler left running alone at the end. Adjust when adding/removing tests:
-#   integration    — 159 tests / 10 workers
+# This file is the single source of truth for test/worker counts. Counts are
+# chosen so tests divide evenly across workers with no straggler left running
+# alone at the end. Adjust when adding/removing tests:
+#   integration    — 160 tests / 10 workers
 #   integration_cf —  13 tests /  7 workers (2+2+2+2+2+2+1)
 #   integration_dns—   8 tests /  4 workers (2+2+2+2)
 #

--- a/zensical.toml
+++ b/zensical.toml
@@ -117,3 +117,11 @@ Components = [
     ] },
 ]
 
+[[project.nav]]
+Contributing = [
+    { "Components" = "docs/contributing/components.md" },
+    { "Unit tests" = "docs/contributing/unit-tests.md" },
+    { "Integration tests" = "docs/contributing/integration-tests.md" },
+    { "Documentation" = "docs/contributing/docs.md" },
+]
+


### PR DESCRIPTION
First pass of the contributing docs we discussed on Monday.

Four pages that will publish under stelvio.dev/docs/contributing/: writing
components, unit tests, integration tests and documentation. Each one is built
around real code from the repo as role models (cron/topic/vpc for components,
test_vpc for unit tests, vpc.md/queues.md for docs) rather than abstract rules.

CONTRIBUTING.md now points to them and its tests section is fixed: integration
tests are the release gate, so infra changes should add or update them — running
them is the optional part if you don't have an account handy, just say so in the
PR. The stale tier commands are gone too; run_all.sh is now the single source of
truth for tiers and worker counts.

These pages describe the current and desired state of the codebase, and all PRs
are expected to follow them — implementation, tests, docs. That goes for both of
us as much as for any new contributor. They're also meant to be living docs: we
should keep updating them as we go, based on PR comments and whatever we learn.

Ideally I'd like to merge this as is and handle any updates in follow-up PRs,
but happy to discuss changes here if needed.