### PR TITLE
chore: align existing code with contributing conventions

### DIFF
--- a/stelvio/aws/cron.py
+++ b/stelvio/aws/cron.py
@@ -131,6 +131,7 @@ class CronCustomizationDict(TypedDict, total=False):
     function: Customization[FunctionCustomizationDict]
 
 
+@final
 class Cron(Component[CronResources, CronCustomizationDict]):
     """Schedule Lambda function execution using EventBridge Rules.
 

--- a/stelvio/aws/topic.py
+++ b/stelvio/aws/topic.py
@@ -288,7 +288,9 @@ class Topic(Component[TopicResources, TopicCustomizationDict], LinkableMixin):
     def _create_resources(self) -> TopicResources:
         suffix = FIFO_SUFFIX if self._fifo else ""
         name = self.name.removesuffix(suffix)
-        topic_name = safe_name(context().prefix(), name, MAX_TOPIC_NAME_LENGTH, suffix=suffix)
+        topic_name = safe_name(
+            context().prefix(), name, MAX_TOPIC_NAME_LENGTH, suffix=suffix, pulumi_suffix_length=0
+        )
 
         topic = sns.Topic(
             topic_name,

--- a/stelvio/command_run.py
+++ b/stelvio/command_run.py
@@ -396,11 +396,6 @@ class CommandRun:
         key = SNAPSHOT_KEY.format(app=self._app_name, env=self.env, update_id=self._update_id)
         self._home.write_file(key, self._state_path)
 
-    def cleanup_state(self) -> None:
-        """Delete state file (after destroy when stack is empty)."""
-        key = STATE_KEY.format(app=self._app_name, env=self.env)
-        self._home.delete_file(key)
-
     def delete_snapshots(self) -> None:
         """Delete all snapshots for this app/env."""
         prefix = f"snapshot/{self._app_name}/{self.env}/"

--- a/tests/aws/test_keyword_only_constructor_params.py
+++ b/tests/aws/test_keyword_only_constructor_params.py
@@ -19,6 +19,7 @@ from stelvio.aws.queue import Queue, QueueSubscription
 from stelvio.aws.s3.s3 import Bucket, BucketNotifySubscription
 from stelvio.aws.s3.s3_static_website import S3StaticWebsite
 from stelvio.aws.topic import Topic, TopicQueueSubscription, TopicSubscription
+from stelvio.aws.vpc import Vpc
 
 
 @pytest.mark.parametrize(
@@ -67,6 +68,8 @@ from stelvio.aws.topic import Topic, TopicQueueSubscription, TopicSubscription
         (HttpApi.__init__, "customize"),
         (ApiDomain.__init__, "tags"),
         (ApiDomain.__init__, "customize"),
+        (Vpc.__init__, "tags"),
+        (Vpc.__init__, "customize"),
     ],
 )
 def test_params_are_keyword_only(callable_obj, param_name):

--- a/tests/aws/test_vpc.py
+++ b/tests/aws/test_vpc.py
@@ -8,6 +8,7 @@ from pytest import mark, param, raises
 
 from stelvio.aws.vpc import NatConfig, NatConfigDict, Vpc
 from tests.aws.pulumi_mocks import TP, R, tid
+from tests.test_utils import assert_config_dict_matches_dataclass
 
 
 @mark.parametrize(
@@ -561,3 +562,7 @@ def test_vpc_resources_parented_to_vpc_component(pulumi_mocks):
             assert "::stelvio:aws:Vpc$" in urn
 
     return pulumi.Output.all(*[res.urn for res in children]).apply(check)
+
+
+def test_nat_config_dict_matches_dataclass():
+    assert_config_dict_matches_dataclass(NatConfig, NatConfigDict)


### PR DESCRIPTION
Small sweep bringing existing code in line with the contributor guidelines (#240):

- add the missing `@final` on `Cron` — the only component without it
- `Topic`: pass `pulumi_suffix_length=0` to `safe_name` — we set an explicit `name`,
  so Pulumi never appends a suffix; no point reserving 8 chars for it
- drop dead `cleanup_state()` (zero callers). Keeping the empty state file after a
  full destroy is deliberate — same default as SST; an opt-in full purge could be a
  future feature
- test guards: `NatConfig`/`NatConfigDict` sync check in the VPC tests, and `Vpc`
  added to the keyword-only-constructor-params suite

No behavior changes.