### PR TITLE
ci: cache uv deps per Python version to speed up 3.15 installs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,10 +33,11 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.11.6"
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install the project
-        run: uv sync --dev --python ${{ matrix.python-version }}
+        run: uv sync --dev
       - name: Run integration tests
         run: ./tests/integration/run_all.sh
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,11 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: "0.11.6"
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install the project
-        run: uv sync --dev --python ${{ matrix.python-version }}
+        run: uv sync --dev
       - name: Run pytest
         run: uv run pytest tests
 


### PR DESCRIPTION
main.yml already has enable-cache: true, but Python version is not part of the cache key.