### PR TITLE
refactor: pass provider explicitly to Component instead of hardwiring AWS in core

### DIFF
--- a/stelvio/aws/acm.py
+++ b/stelvio/aws/acm.py
@@ -46,7 +46,12 @@ class AcmValidatedDomain(
         parent: pulumi.Resource | None = None,
     ):
         super().__init__(
-            "stelvio:aws:AcmValidatedDomain", name, tags=tags, customize=customize, parent=parent
+            ProviderStore.aws(),
+            "stelvio:aws:AcmValidatedDomain",
+            name,
+            tags=tags,
+            customize=customize,
+            parent=parent,
         )
         self._domain_name = domain_name
         self._region = region

--- a/stelvio/aws/api_gateway/domain.py
+++ b/stelvio/aws/api_gateway/domain.py
@@ -11,6 +11,7 @@ from stelvio.aws.acm import AcmValidatedDomain
 from stelvio.aws.api_gateway.validators import validate_domain_name
 from stelvio.component import Component
 from stelvio.dns import Dns, DnsProviderNotConfiguredError, Record
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     import pulumi
@@ -60,7 +61,12 @@ class ApiDomain(Component[ApiDomainResources, ApiDomainCustomizationDict]):
         parent: pulumi.Resource | None = None,
     ) -> None:
         super().__init__(
-            "stelvio:aws:ApiDomain", name, tags=tags, customize=customize, parent=parent
+            ProviderStore.aws(),
+            "stelvio:aws:ApiDomain",
+            name,
+            tags=tags,
+            customize=customize,
+            parent=parent,
         )
         validate_domain_name(domain_name)
         if certificate_arn is not None and (customize or {}).get("certificate") is not None:

--- a/stelvio/aws/api_gateway/http_api/http_api.py
+++ b/stelvio/aws/api_gateway/http_api/http_api.py
@@ -40,6 +40,7 @@ from stelvio.aws.function import (
 )
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from stelvio.aws.api_gateway.rest_api.constants import HTTPMethodInput
@@ -163,7 +164,9 @@ class HttpApi(
         customize: HttpApiCustomizationDict | None = None,
         **opts: Unpack[HttpApiConfigDict],
     ) -> None:
-        super().__init__("stelvio:aws:HttpApi", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:HttpApi", name, tags=tags, customize=customize
+        )
         self._routes = []
         self._authorizers = {}
         self._default_auth = None

--- a/stelvio/aws/api_gateway/rest_api/rest_api.py
+++ b/stelvio/aws/api_gateway/rest_api/rest_api.py
@@ -52,6 +52,7 @@ from stelvio.aws.function.function import FunctionEnvVarsRegistry
 from stelvio.component import Component, ComponentRegistry, link_config_creator, safe_name
 from stelvio.dns import DnsProviderNotConfiguredError
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -103,7 +104,9 @@ class RestApi(Component[RestApiResources, RestApiCustomizationDict], LinkableMix
         customize: RestApiCustomizationDict | None = None,
         **opts: Unpack[RestApiConfigDict],
     ) -> None:
-        super().__init__("stelvio:aws:RestApi", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:RestApi", name, tags=tags, customize=customize
+        )
         self._routes = []
         self._authorizers = []
         self._default_auth = None

--- a/stelvio/aws/api_gateway/websocket_api/websocket_api.py
+++ b/stelvio/aws/api_gateway/websocket_api/websocket_api.py
@@ -27,6 +27,7 @@ from stelvio.aws.function import Function, FunctionConfig, FunctionConfigDict, p
 from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 DEFAULT_ROUTE_SELECTION_EXPRESSION = "$request.body.action"
 _RESERVED_ROUTE_KEYS = frozenset({"$connect", "$disconnect", "$default"})
@@ -176,7 +177,9 @@ class WebsocketApi(
         customize: WebsocketApiCustomizationDict | None = None,
         **opts: Unpack[WebsocketApiConfigDict],
     ) -> None:
-        super().__init__("stelvio:aws:WebsocketApi", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:WebsocketApi", name, tags=tags, customize=customize
+        )
         self._routes = []
         self._authorizers = {}
         if config is not None and opts:

--- a/stelvio/aws/appsync/appsync.py
+++ b/stelvio/aws/appsync/appsync.py
@@ -43,6 +43,7 @@ from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.dns import DnsProviderNotConfiguredError, Record
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 _DS_TYPES_REQUIRING_CODE = {DS_TYPE_DYNAMO, DS_TYPE_HTTP, DS_TYPE_RDS, DS_TYPE_OPENSEARCH}
 
@@ -89,7 +90,9 @@ class AppSync(Component[AppSyncResources, AppSyncCustomizationDict], LinkableMix
         customize: AppSyncCustomizationDict | None = None,
         **opts: Unpack[AppSyncConfigDict],
     ) -> None:
-        super().__init__("stelvio:aws:AppSync", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:AppSync", name, tags=tags, customize=customize
+        )
 
         self._config = self._parse_config(config, opts)
         self._schema = read_schema_input(self._config.schema)

--- a/stelvio/aws/appsync/data_source.py
+++ b/stelvio/aws/appsync/data_source.py
@@ -17,6 +17,7 @@ from stelvio.aws.appsync.constants import (
 )
 from stelvio.aws.function import Function, FunctionConfig
 from stelvio.component import Component, safe_name
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from stelvio.aws.appsync.appsync import AppSync
@@ -135,6 +136,7 @@ class AppSyncDataSource(Component[AppSyncDataSourceResources, AppSyncDataSourceC
     ) -> None:
         self._data_source_name = name
         super().__init__(
+            ProviderStore.aws(),
             "stelvio:aws:AppSyncDataSource",
             f"{api.name}-ds-{name}",
             tags=tags,

--- a/stelvio/aws/appsync/resolver.py
+++ b/stelvio/aws/appsync/resolver.py
@@ -16,6 +16,7 @@ from stelvio.aws.appsync.constants import (
 )
 from stelvio.aws.appsync.file_inputs import read_js_code_input
 from stelvio.component import Component, safe_name
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from stelvio.aws.appsync.appsync import AppSync
@@ -57,6 +58,7 @@ class AppSyncResolver(Component[AppSyncResolverResources, AppSyncResolverCustomi
         customize: AppSyncResolverCustomizationDict | None = None,
     ) -> None:
         super().__init__(
+            ProviderStore.aws(),
             "stelvio:aws:AppSyncResolver",
             f"{api.name}-resolver-{config.type_name}-{config.field_name}",
             customize=customize,
@@ -144,7 +146,12 @@ class PipeFunction(Component[AppSyncPipeFunctionResources, AppSyncPipeFunctionCu
         customize: AppSyncPipeFunctionCustomizationDict | None = None,
     ) -> None:
         self._pipe_function_name = name
-        super().__init__("stelvio:aws:PipeFunction", f"{api.name}-fn-{name}", customize=customize)
+        super().__init__(
+            ProviderStore.aws(),
+            "stelvio:aws:PipeFunction",
+            f"{api.name}-fn-{name}",
+            customize=customize,
+        )
         self._api = api
         self._data_source = data_source
         self._code = code

--- a/stelvio/aws/cloudfront/cloudfront.py
+++ b/stelvio/aws/cloudfront/cloudfront.py
@@ -10,6 +10,7 @@ from stelvio import context
 from stelvio.aws.acm import AcmValidatedDomain, AcmValidatedDomainCustomizationDict
 from stelvio.component import Component
 from stelvio.dns import DnsProviderNotConfiguredError
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.cloudfront import CachePolicyArgs, DistributionArgs, OriginAccessControlArgs
@@ -81,6 +82,7 @@ class CloudFrontDistribution(
                 which creates a CloudFrontDistribution internally.
         """
         super().__init__(
+            ProviderStore.aws(),
             "stelvio:aws:CloudFrontDistribution",
             name,
             tags=tags,

--- a/stelvio/aws/cloudfront/origins/components/url.py
+++ b/stelvio/aws/cloudfront/origins/components/url.py
@@ -24,7 +24,7 @@ class UrlResources:
 @final
 class Url(Component[UrlResources, Any], LinkableMixin):
     def __init__(self, name: str, url: str, *, tags: dict[str, str] | None = None):
-        super().__init__("stelvio:aws:Url", name, tags=tags)
+        super().__init__(ProviderStore.aws(), "stelvio:aws:Url", name, tags=tags)
         self._validate_url(url)
         self.url = url
 

--- a/stelvio/aws/cloudfront/router.py
+++ b/stelvio/aws/cloudfront/router.py
@@ -16,6 +16,7 @@ from stelvio.aws.cloudfront.origins.registry import CloudfrontAdapterRegistry
 from stelvio.aws.function import Function, FunctionUrlConfig, FunctionUrlConfigDict
 from stelvio.component import Component
 from stelvio.dns import DnsProviderNotConfiguredError, Record
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.cloudfront import DistributionArgs, FunctionArgs, OriginAccessControlArgs
@@ -57,7 +58,9 @@ class Router(Component[RouterResources, RouterCustomizationDict]):
         tags: dict[str, str] | None = None,
         customize: RouterCustomizationDict | None = None,
     ):
-        super().__init__("stelvio:aws:Router", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:Router", name, tags=tags, customize=customize
+        )
         self.routes = routes or []
         self.price_class = price_class
         self.custom_domain = custom_domain

--- a/stelvio/aws/cognito/identity_pool.py
+++ b/stelvio/aws/cognito/identity_pool.py
@@ -20,6 +20,7 @@ from stelvio.aws.cognito.user_pool import UserPool
 from stelvio.aws.cognito.user_pool_client import UserPoolClient
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from stelvio.aws.permission import AwsPermission
@@ -141,7 +142,9 @@ class IdentityPool(
         customize: IdentityPoolCustomizationDict | None = None,
         **opts: Unpack[IdentityPoolConfigDict],
     ) -> None:
-        super().__init__("stelvio:aws:IdentityPool", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:IdentityPool", name, tags=tags, customize=customize
+        )
         self._config = self._parse_config(config, opts)
 
     @staticmethod

--- a/stelvio/aws/cognito/identity_provider.py
+++ b/stelvio/aws/cognito/identity_provider.py
@@ -10,6 +10,7 @@ from stelvio import context
 from stelvio.aws.cognito.types import IdentityProviderConfig, IdentityProviderCustomizationDict
 from stelvio.aws.cognito.user_pool import UserPool  # noqa: TC001
 from stelvio.component import Component, safe_name
+from stelvio.provider import ProviderStore
 
 MAX_IDENTITY_PROVIDER_NAME_LENGTH = 128
 
@@ -40,7 +41,9 @@ class IdentityProvider(Component[IdentityProviderResources, IdentityProviderCust
         config: IdentityProviderConfig,
         customize: IdentityProviderCustomizationDict | None = None,
     ) -> None:
-        super().__init__("stelvio:aws:IdentityProvider", name, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:IdentityProvider", name, customize=customize
+        )
         self._user_pool = user_pool
         self._config = config
 

--- a/stelvio/aws/cognito/user_pool.py
+++ b/stelvio/aws/cognito/user_pool.py
@@ -24,6 +24,7 @@ from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.dns import DnsProviderNotConfiguredError, Record
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi import Output
@@ -99,7 +100,9 @@ class UserPool(
         customize: UserPoolCustomizationDict | None = None,
         **opts: Unpack[UserPoolConfigDict],
     ) -> None:
-        super().__init__("stelvio:aws:UserPool", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:UserPool", name, tags=tags, customize=customize
+        )
         self._config = self._parse_config(config, opts)
         self._clients: list[UserPoolClient] = []
         self._identity_providers: list[IdentityProvider] = []

--- a/stelvio/aws/cognito/user_pool_client.py
+++ b/stelvio/aws/cognito/user_pool_client.py
@@ -15,6 +15,7 @@ from stelvio.aws.cognito.user_pool import UserPool  # noqa: TC001
 from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     import pulumi
@@ -47,7 +48,9 @@ class UserPoolClient(
         customize: UserPoolClientCustomizationDict | None = None,
         **opts: Unpack[UserPoolClientConfigDict],
     ) -> None:
-        super().__init__("stelvio:aws:UserPoolClient", name, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:UserPoolClient", name, customize=customize
+        )
         self._pool = pool
         self._config = self._parse_config(config, opts)
 

--- a/stelvio/aws/cron.py
+++ b/stelvio/aws/cron.py
@@ -11,6 +11,7 @@ from pulumi_aws import cloudwatch, lambda_
 from stelvio import context
 from stelvio.aws.function import Function, FunctionConfig, FunctionConfigDict
 from stelvio.component import Component, safe_name
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.cloudwatch import EventRuleArgs, EventTargetArgs
@@ -189,7 +190,9 @@ class Cron(Component[CronResources, CronCustomizationDict]):
         customize: CronCustomizationDict | None = None,
         **opts: Unpack[FunctionConfigDict],
     ):
-        super().__init__("stelvio:aws:Cron", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:Cron", name, tags=tags, customize=customize
+        )
 
         # Validate and parse inputs using pure functions
         _validate_schedule(schedule)

--- a/stelvio/aws/dynamo_db.py
+++ b/stelvio/aws/dynamo_db.py
@@ -18,6 +18,7 @@ from stelvio.aws.function import (
 from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import Link, LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi import Output, Resource
@@ -255,6 +256,7 @@ class DynamoSubscription(
     ):
         # Add suffix because we want to use 'name' for Function, avoiding component name conflicts
         super().__init__(
+            ProviderStore.aws(),
             "stelvio:aws:DynamoSubscription",
             f"{name}-subscription",
             tags=tags,
@@ -342,7 +344,9 @@ class DynamoTable(Component[DynamoTableResources, DynamoTableCustomizationDict],
         customize: DynamoTableCustomizationDict | None = None,
         **opts: Unpack[DynamoTableConfigDict],
     ):
-        super().__init__("stelvio:aws:DynamoTable", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:DynamoTable", name, tags=tags, customize=customize
+        )
 
         self._config = self._parse_config(config, opts)
         self._subscriptions = []

--- a/stelvio/aws/email.py
+++ b/stelvio/aws/email.py
@@ -10,6 +10,7 @@ from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator
 from stelvio.dns import Dns, DnsProviderNotConfiguredError, Record
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.ses import DomainIdentityVerificationArgs
@@ -104,7 +105,9 @@ class Email(Component[EmailResources, EmailCustomizationDict], LinkableMixin):
         customize: EmailCustomizationDict | None = None,
         **opts: Unpack[EmailConfigDict],
     ):
-        super().__init__("stelvio:aws:Email", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:Email", name, tags=tags, customize=customize
+        )
         self._config = self._parse_config(config, opts)
         self.is_domain = "@" not in self.config.sender
         # We allow passing in a DNS provider since email verification may

--- a/stelvio/aws/function/function.py
+++ b/stelvio/aws/function/function.py
@@ -57,6 +57,7 @@ from stelvio.component import (
 )
 from stelvio.link import Link, Linkable, LinkableMixin, LinkConfig
 from stelvio.project import get_project_root
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
@@ -135,7 +136,12 @@ class Function(
             **opts: Inline function config options (alternative to ``config``).
         """
         super().__init__(
-            "stelvio:aws:Function", name, tags=tags, customize=customize, parent=parent
+            ProviderStore.aws(),
+            "stelvio:aws:Function",
+            name,
+            tags=tags,
+            customize=customize,
+            parent=parent,
         )
 
         self._config = self._parse_config(config, opts)

--- a/stelvio/aws/layer.py
+++ b/stelvio/aws/layer.py
@@ -20,6 +20,7 @@ from stelvio.aws._packaging.dependencies import (
 from stelvio.aws.function.constants import DEFAULT_ARCHITECTURE, DEFAULT_RUNTIME
 from stelvio.component import Component
 from stelvio.project import get_project_root
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.lambda_ import LayerVersionArgs
@@ -105,7 +106,7 @@ class Layer(Component[LayerResources, LayerCustomizationDict]):
         customize: LayerCustomizationDict | None = None,
         **opts: Unpack[LayerConfigDict],
     ):
-        super().__init__("stelvio:aws:Layer", name, customize=customize)
+        super().__init__(ProviderStore.aws(), "stelvio:aws:Layer", name, customize=customize)
         self._config = self._parse_config(config, opts)
 
         if not self._config.code and not self._config.requirements:

--- a/stelvio/aws/queue.py
+++ b/stelvio/aws/queue.py
@@ -20,6 +20,7 @@ from stelvio.aws.function import (
 from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import Link, LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.lambda_ import EventSourceMappingArgs
@@ -129,6 +130,7 @@ class QueueSubscription(Component[QueueSubscriptionResources, QueueSubscriptionC
     ):
         # Add suffix because we want to use 'name' for Function, avoiding component name conflicts
         super().__init__(
+            ProviderStore.aws(),
             "stelvio:aws:QueueSubscription",
             f"{name}-subscription",
             tags=tags,
@@ -291,7 +293,9 @@ class Queue(Component[QueueResources, QueueCustomizationDict], LinkableMixin):
         customize: QueueCustomizationDict | None = None,
         **opts: Unpack[QueueConfigDict],
     ):
-        super().__init__("stelvio:aws:Queue", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:Queue", name, tags=tags, customize=customize
+        )
         self._config = self._parse_config(config, opts)
         self._subscriptions = []
 

--- a/stelvio/aws/s3/s3.py
+++ b/stelvio/aws/s3/s3.py
@@ -14,6 +14,7 @@ from stelvio.aws.queue import Queue
 from stelvio.aws.topic import Topic
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import Link, Linkable, LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -122,6 +123,7 @@ class BucketNotifySubscription(
         parent: pulumi.Resource | None = None,
     ):
         super().__init__(
+            ProviderStore.aws(),
             "stelvio:aws:BucketNotifySubscription",
             f"{name}-subscription",
             tags=tags,
@@ -415,7 +417,14 @@ class Bucket(Component[BucketResources, BucketCustomizationDict], LinkableMixin)
             parent: Parent resource for nesting. Used by components like
                 S3StaticWebsite that create Buckets internally.
         """
-        super().__init__("stelvio:aws:Bucket", name, tags=tags, customize=customize, parent=parent)
+        super().__init__(
+            ProviderStore.aws(),
+            "stelvio:aws:Bucket",
+            name,
+            tags=tags,
+            customize=customize,
+            parent=parent,
+        )
         self.versioning = versioning
         self.access = access
         self._subscriptions = []

--- a/stelvio/aws/s3/s3_static_website.py
+++ b/stelvio/aws/s3/s3_static_website.py
@@ -13,6 +13,7 @@ from stelvio import context
 from stelvio.aws.cloudfront import CloudFrontDistribution
 from stelvio.aws.s3.s3 import Bucket, BucketCustomizationDict
 from stelvio.component import Component, safe_name
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.s3 import BucketObjectArgs
@@ -66,7 +67,13 @@ class S3StaticWebsite(Component[S3StaticWebsiteResources, S3StaticWebsiteCustomi
         tags: dict[str, str] | None = None,
         customize: S3StaticWebsiteCustomizationDict | None = None,
     ):
-        super().__init__("stelvio:aws:S3StaticWebsite", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(),
+            "stelvio:aws:S3StaticWebsite",
+            name,
+            tags=tags,
+            customize=customize,
+        )
         self.directory = Path(directory) if isinstance(directory, str) else directory
         self.custom_domain = custom_domain
         self.default_cache_ttl = default_cache_ttl

--- a/stelvio/aws/topic.py
+++ b/stelvio/aws/topic.py
@@ -20,6 +20,7 @@ from stelvio.aws.permission import AwsPermission
 from stelvio.aws.queue import Queue
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi_aws.lambda_ import PermissionArgs
@@ -82,6 +83,7 @@ class TopicSubscription(Component[TopicSubscriptionResources, TopicSubscriptionC
         parent: pulumi.Resource | None = None,
     ):
         super().__init__(
+            ProviderStore.aws(),
             "stelvio:aws:TopicSubscription",
             f"{name}-subscription",
             tags=tags,
@@ -158,7 +160,11 @@ class TopicQueueSubscription(
         parent: pulumi.Resource | None = None,
     ):
         super().__init__(
-            "stelvio:aws:TopicQueueSubscription", name, customize=customize, parent=parent
+            ProviderStore.aws(),
+            "stelvio:aws:TopicQueueSubscription",
+            name,
+            customize=customize,
+            parent=parent,
         )
         self._topic = topic
         self._queue = queue
@@ -273,7 +279,9 @@ class Topic(Component[TopicResources, TopicCustomizationDict], LinkableMixin):
         tags: dict[str, str] | None = None,
         customize: TopicCustomizationDict | None = None,
     ):
-        super().__init__("stelvio:aws:Topic", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:Topic", name, tags=tags, customize=customize
+        )
         self._fifo = fifo
         self._subscriptions = []
         self._queue_subscriptions = []

--- a/stelvio/aws/vpc.py
+++ b/stelvio/aws/vpc.py
@@ -24,6 +24,7 @@ from pulumi_aws.ec2 import Vpc as PulumiVpc
 
 from stelvio import context
 from stelvio.component import Component, safe_name
+from stelvio.provider import ProviderStore
 
 if TYPE_CHECKING:
     from pulumi import Input
@@ -147,7 +148,9 @@ class Vpc(Component[VpcResources, VpcCustomizationDict]):
         tags: dict[str, str] | None = None,
         customize: VpcCustomizationDict | None = None,
     ):
-        super().__init__("stelvio:aws:Vpc", name, tags=tags, customize=customize)
+        super().__init__(
+            ProviderStore.aws(), "stelvio:aws:Vpc", name, tags=tags, customize=customize
+        )
         _validate_az(az)
         self._az = az
         self._nat_config = _normalize_nat(nat)

--- a/stelvio/component.py
+++ b/stelvio/component.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol, get_args, get_origin
 import pulumi
 
 from stelvio import context
-from stelvio.provider import ProviderStore
 from stelvio.pulumi import normalize_pulumi_args_to_dict
 
 _normalize = normalize_pulumi_args_to_dict
@@ -29,9 +28,11 @@ class Component[ResourcesT, CustomizationT](pulumi.ComponentResource, ABC):
     _resources: ResourcesT | None
     _customize: CustomizationT
     _tags: dict[str, str]
+    _provider: pulumi.ProviderResource
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
+        provider: pulumi.ProviderResource,
         type_name: str,
         name: str,
         *,
@@ -42,6 +43,7 @@ class Component[ResourcesT, CustomizationT](pulumi.ComponentResource, ABC):
         """Initialize a Stelvio component.
 
         Args:
+            provider: Provider this component's resources deploy through.
             type_name: Pulumi type URN (e.g., ``"stelvio:aws:Function"``).
             name: Globally unique component name.
             tags: AWS tags applied to taggable child resources.
@@ -51,13 +53,14 @@ class Component[ResourcesT, CustomizationT](pulumi.ComponentResource, ABC):
                 Function). Sets up the proper resource tree hierarchy and adds an
                 alias for migration from the root stack.
         """
-        resource_opts = pulumi.ResourceOptions(providers=[ProviderStore.aws()], parent=parent)
+        resource_opts = pulumi.ResourceOptions(providers=[provider], parent=parent)
         if parent is not None:
             # Allow migration from previously top-level components when introducing
             # parent relationships in composed components.
             resource_opts.aliases = [pulumi.Alias(parent=pulumi.ROOT_STACK_RESOURCE)]
         super().__init__(type_name, name, None, resource_opts)
         self._name = name
+        self._provider = provider
         self._resources = None
         self._customize = customize or {}
         self._tags = tags or {}

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -9,6 +9,7 @@ from stelvio import context
 from stelvio.component import Component, ComponentRegistry, link_config_creator
 from stelvio.context import _ContextStore
 from stelvio.link import LinkConfig
+from stelvio.provider import ProviderStore
 
 
 class _MinimalMocks(Mocks):
@@ -42,7 +43,12 @@ class MockComponent(Component[MockComponentResources, dict]):
         parent: pulumi.Resource | None = None,
     ):
         super().__init__(
-            "stelvio:test:MockComponent", name, tags=tags, customize=customize, parent=parent
+            ProviderStore.aws(),
+            "stelvio:test:MockComponent",
+            name,
+            tags=tags,
+            customize=customize,
+            parent=parent,
         )
         self._mock_resource = resource or MockResource(name)
         # Track if _create_resource was called


### PR DESCRIPTION
Component.__init__ now takes the provider as its first parameter and each AWS component passes ProviderStore.aws() explicitly, removing the AWS hardwiring from the cloud-agnostic core. No behavior or URN changes; full suite unchanged. Groundwork for the region fix stacked on top (#262), and the seam for future multi-region support.

Rebased on #264/#266: the new WebsocketApi passes ProviderStore.aws() too, same as every other component.