### PR TITLE
fix: resolve default AWS region via the standard chain when not configured

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - **Subscription parenting.** `TopicSubscription`, `TopicQueueSubscription`, `QueueSubscription`, `DynamoSubscription`, and `BucketNotifySubscription` are now parented under their owning `Topic`/`Queue`/`DynamoTable`/`Bucket`, so they nest in the resource tree and deploy output instead of sitting at the stack root. Root-stack aliases migrate existing stacks in place — no replacements. Subscription constructors also accept a keyword-only `parent`, matching `Function`.
+- **Default AWS region resolution.** With no `region` in `@app.config`, Stelvio now resolves the region once via the standard AWS chain (`AWS_REGION`, `AWS_DEFAULT_REGION`, profile config) and uses it everywhere. Previously a missing region put a literal `None` into region-based values, breaking `IdentityPool` deploys and AppSync DynamoDB data sources — and setting only `AWS_REGION` (which boto3 ignores) didn't work. When no region can be resolved at all, Stelvio fails fast with a clear error.
 
 ### Breaking Changes
 - `Api` component (AWS API Gateway v1) is renamed to `RestApi`. **Caution**: This change will affect existing deployments. Users with a custom domain should expect the update to fail on the duplicate domain: remove the custom domain first (by setting `custom_domain=None` and redeploy), then re-add it and deploy again. For users without a custom domain, the update should succeed without issues, but the `invoke_url` will change on redeploy. This behavior is expected as Stelvio will remove existing API and recreate it.

--- a/stelvio/aws/__init__.py
+++ b/stelvio/aws/__init__.py
@@ -1,1 +1,19 @@
 """AWS components for Stelvio."""
+
+from stelvio.provider import ProviderStore
+
+__all__ = ["default_region"]
+
+
+def default_region() -> str:
+    """Get the app's default AWS region.
+
+    The region set in `AwsConfig(region=...)`, or — when not set — the one resolved
+    from the standard AWS chain (`AWS_REGION`, profile config). This is the region
+    all Stelvio resources deploy to unless a component says otherwise.
+
+    Raises:
+        StelvioValidationError: If no region is configured anywhere.
+        RuntimeError: If called outside a Stelvio deployment operation.
+    """
+    return ProviderStore.region()

--- a/stelvio/aws/__init__.py
+++ b/stelvio/aws/__init__.py
@@ -9,8 +9,8 @@ def default_region() -> str:
     """Get the app's default AWS region.
 
     The region set in `AwsConfig(region=...)`, or — when not set — the one resolved
-    from the standard AWS chain (`AWS_REGION`, profile config). This is the region
-    all Stelvio resources deploy to unless a component says otherwise.
+    from the standard AWS chain (`AWS_REGION`, `AWS_DEFAULT_REGION`, profile config).
+    This is the region all Stelvio resources deploy to unless a component says otherwise.
 
     Raises:
         StelvioValidationError: If no region is configured anywhere.

--- a/stelvio/aws/acm.py
+++ b/stelvio/aws/acm.py
@@ -64,10 +64,9 @@ class AcmValidatedDomain(
                 "Please set up a DNS provider to use custom domains."
             )
 
-        # Use ProviderStore for cross-region provider when needed
-        cross_region_provider = None
-        if self._region and self._region != context().aws.region:
-            cross_region_provider = ProviderStore.aws_for_region(self._region)
+        cross_region_provider = (
+            ProviderStore.aws_for_region(self._region) if self._region else None
+        )
 
         # 1 - Issue Certificate
         certificate = pulumi_aws.acm.Certificate(

--- a/stelvio/aws/api_gateway/http_api/http_api.py
+++ b/stelvio/aws/api_gateway/http_api/http_api.py
@@ -40,7 +40,7 @@ from stelvio.aws.function import (
 )
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
-from stelvio.provider import ProviderStore
+from stelvio.provider import ProviderStore, aws_region_of
 
 if TYPE_CHECKING:
     from stelvio.aws.api_gateway.rest_api.constants import HTTPMethodInput
@@ -318,7 +318,7 @@ class HttpApi(
             region, pool_id = _parse_user_pool_arn(name, user_pool)
             issuer = Output.from_input(f"https://cognito-idp.{region}.amazonaws.com/{pool_id}")
         else:
-            region = context().aws.region
+            region = aws_region_of(user_pool)
             issuer = Output.concat(
                 f"https://cognito-idp.{region}.amazonaws.com/",
                 user_pool.resources.user_pool.id,

--- a/stelvio/aws/api_gateway/websocket_api/websocket_api.py
+++ b/stelvio/aws/api_gateway/websocket_api/websocket_api.py
@@ -27,7 +27,7 @@ from stelvio.aws.function import Function, FunctionConfig, FunctionConfigDict, p
 from stelvio.aws.permission import AwsPermission
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
-from stelvio.provider import ProviderStore
+from stelvio.provider import ProviderStore, aws_region_of
 
 DEFAULT_ROUTE_SELECTION_EXPRESSION = "$request.body.action"
 _RESERVED_ROUTE_KEYS = frozenset({"$connect", "$disconnect", "$default"})
@@ -326,8 +326,7 @@ class WebsocketApi(
         stage_name = self._customizer("stage", {"name": self._config.stage_name}).get(
             "name", self._config.stage_name
         )
-        # region: see #262
-        region = context().aws.region
+        region = aws_region_of(self)
         return self._api_resource.id.apply(
             lambda api_id: f"{scheme}://{api_id}.execute-api.{region}.amazonaws.com/{stage_name}"
         )

--- a/stelvio/aws/appsync/data_source.py
+++ b/stelvio/aws/appsync/data_source.py
@@ -17,7 +17,7 @@ from stelvio.aws.appsync.constants import (
 )
 from stelvio.aws.function import Function, FunctionConfig
 from stelvio.component import Component, safe_name
-from stelvio.provider import ProviderStore
+from stelvio.provider import ProviderStore, aws_region_of
 
 if TYPE_CHECKING:
     from stelvio.aws.appsync.appsync import AppSync
@@ -224,7 +224,8 @@ class AppSyncDataSource(Component[AppSyncDataSourceResources, AppSyncDataSourceC
                 raise RuntimeError(f"Dynamo data source '{self.name}' requires a table")
             extra["dynamodb_config"] = {
                 "table_name": self._config.table.resources.table.name,
-                "region": context().aws.region,
+                # The table's region, not ours — they can differ under multi-region
+                "region": aws_region_of(self._config.table),
             }
         elif self.ds_type == DS_TYPE_HTTP:
             if self._config.url is None:

--- a/stelvio/aws/cloudfront/origins/components/api_gateway.py
+++ b/stelvio/aws/cloudfront/origins/components/api_gateway.py
@@ -5,6 +5,7 @@ from stelvio.aws.api_gateway import RestApi
 from stelvio.aws.cloudfront.dtos import Route, RouteOriginConfig
 from stelvio.aws.cloudfront.origins.base import ComponentCloudfrontAdapter
 from stelvio.aws.cloudfront.origins.decorators import register_adapter
+from stelvio.provider import aws_region_of
 
 
 @register_adapter(RestApi)
@@ -16,7 +17,7 @@ class ApiGatewayCloudfrontAdapter(ComponentCloudfrontAdapter):
         self.api = route.component
 
     def get_origin_config(self) -> RouteOriginConfig:
-        region = pulumi_aws.get_region().region
+        region = aws_region_of(self.api)
         origin_args = pulumi_aws.cloudfront.DistributionOriginArgs(
             origin_id=self.api.resources.rest_api.id,
             domain_name=self.api.resources.rest_api.id.apply(

--- a/stelvio/aws/cloudfront/origins/components/http_api.py
+++ b/stelvio/aws/cloudfront/origins/components/http_api.py
@@ -5,7 +5,7 @@ from stelvio.aws.api_gateway.http_api import HttpApi
 from stelvio.aws.cloudfront.dtos import Route, RouteOriginConfig
 from stelvio.aws.cloudfront.origins.base import ComponentCloudfrontAdapter
 from stelvio.aws.cloudfront.origins.decorators import register_adapter
-from stelvio.context import context
+from stelvio.provider import aws_region_of
 
 
 @register_adapter(HttpApi)
@@ -17,7 +17,7 @@ class HttpApiCloudfrontAdapter(ComponentCloudfrontAdapter):
         self.api = route.component
 
     def get_origin_config(self) -> RouteOriginConfig:
-        region = context().aws.region
+        region = aws_region_of(self.api)
         stage_name = self.api.config.stage_name
         custom_domain_name = self.api.domain_name
         origin_path = self._origin_path(custom_domain_name, stage_name)

--- a/stelvio/aws/cognito/identity_pool.py
+++ b/stelvio/aws/cognito/identity_pool.py
@@ -4,7 +4,6 @@ import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Unpack, final
 
-import pulumi
 import pulumi_aws
 from pulumi import Output
 from pulumi_aws.iam import RolePolicy
@@ -20,7 +19,7 @@ from stelvio.aws.cognito.user_pool import UserPool
 from stelvio.aws.cognito.user_pool_client import UserPoolClient
 from stelvio.component import Component, link_config_creator, safe_name
 from stelvio.link import LinkableMixin, LinkConfig
-from stelvio.provider import ProviderStore
+from stelvio.provider import ProviderStore, aws_region_of
 
 if TYPE_CHECKING:
     from stelvio.aws.permission import AwsPermission
@@ -42,11 +41,9 @@ def _resolve_binding(binding: IdentityPoolBinding) -> dict[str, Any]:
 
     if isinstance(binding.user_pool, UserPool):
         pool_id = binding.user_pool.id
-        # Component-managed pools are always in the app's region
-        region = context().aws.region
-        provider_name = pulumi.Output.all(region=region, pool_id=pool_id).apply(
-            lambda args: f"cognito-idp.{args['region']}.amazonaws.com/{args['pool_id']}"
-        )
+        # Component-managed pools live in their provider's region
+        region = aws_region_of(binding.user_pool)
+        provider_name = pool_id.apply(lambda pid: f"cognito-idp.{region}.amazonaws.com/{pid}")
     else:
         pool_id = binding.user_pool
         # Parse region from pool ID prefix (format: {region}_{id})

--- a/stelvio/aws/function/function.py
+++ b/stelvio/aws/function/function.py
@@ -57,7 +57,7 @@ from stelvio.component import (
 )
 from stelvio.link import Link, Linkable, LinkableMixin, LinkConfig
 from stelvio.project import get_project_root
-from stelvio.provider import ProviderStore
+from stelvio.provider import ProviderStore, aws_region_of
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
@@ -269,8 +269,10 @@ class Function(
         }
 
         if context().dev_mode:
+            # The bridge is shared app-level dev infra: ONE AppSync in the app's
+            # default region; stubs in any region reach it over plain HTTPS/WSS.
             appsync_bridge = discover_or_create_appsync(
-                region=context().aws.region, profile=context().aws.profile
+                region=ProviderStore.region(), profile=context().aws.profile
             )
 
             WebsocketHandlers.register(self)
@@ -419,10 +421,10 @@ class Function(
 
     async def _get_environment_for_bridge_event(self) -> dict[str, str]:
         new_environ = {}
-        # Inject AWS context into environment for boto3
-        if context().aws.region:
-            new_environ["AWS_REGION"] = context().aws.region
-            new_environ["AWS_DEFAULT_REGION"] = context().aws.region
+        # Emulate the Lambda runtime: AWS_REGION is always the function's own region
+        region = aws_region_of(self)
+        new_environ["AWS_REGION"] = region
+        new_environ["AWS_DEFAULT_REGION"] = region
 
         if context().aws.profile:
             new_environ["AWS_PROFILE"] = context().aws.profile

--- a/stelvio/aws/vpc.py
+++ b/stelvio/aws/vpc.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Final, Literal, NamedTuple, TypedDict, final
 
-from pulumi_aws import get_availability_zones, get_region
+from pulumi_aws import get_availability_zones
 from pulumi_aws.ec2 import (
     Eip,
     EipArgs,
@@ -24,7 +24,7 @@ from pulumi_aws.ec2 import Vpc as PulumiVpc
 
 from stelvio import context
 from stelvio.component import Component, safe_name
-from stelvio.provider import ProviderStore
+from stelvio.provider import ProviderStore, aws_region_of
 
 if TYPE_CHECKING:
     from pulumi import Input
@@ -157,7 +157,7 @@ class Vpc(Component[VpcResources, VpcCustomizationDict]):
         _validate_nat_config(self._nat_config, self._az)
 
     def _create_resources(self) -> VpcResources:
-        azs = _get_az_names(self._az)
+        azs = _get_az_names(self._az, aws_region_of(self))
         vpc = self._create_vpc()
         igw = self._create_internet_gateway(vpc)
         subnets_dict, route_tables_dict = self._create_subnets_with_route_tables(vpc, igw, azs)
@@ -351,9 +351,8 @@ def _validate_az(az: int | list[str]) -> None:
     raise TypeError(f"`az` parameter must be `int` or `list[str]`, got {type(az).__name__}")
 
 
-def _get_az_names(az: int | list[str]) -> list[str]:
-    available_azs_names = list(get_availability_zones(state="available").names)
-    region_name = get_region().region
+def _get_az_names(az: int | list[str], region_name: str) -> list[str]:
+    available_azs_names = list(get_availability_zones(state="available", region=region_name).names)
     if isinstance(az, int):
         if az > len(available_azs_names):
             raise ValueError(

--- a/stelvio/bridge/remote/infrastructure.py
+++ b/stelvio/bridge/remote/infrastructure.py
@@ -55,9 +55,7 @@ class AppSyncResource:
 
 
 @cache
-def discover_or_create_appsync(
-    region: str = "us-east-1", profile: str | None = None
-) -> AppSyncResource:
+def discover_or_create_appsync(region: str, profile: str | None = None) -> AppSyncResource:
     """
     Discover AppSync Event API by name, or create if doesn't exist.
 

--- a/stelvio/cli/commands.py
+++ b/stelvio/cli/commands.py
@@ -24,6 +24,7 @@ from stelvio.cli.json_output import (
 )
 from stelvio.cli.state_rendering import format_state_tree_lines
 from stelvio.command_run import CommandRun, force_unlock
+from stelvio.provider import ProviderStore
 from stelvio.pulumi import _show_simple_error, print_operation_header
 from stelvio.rich_deployment_handler import RichDeploymentHandler
 from stelvio.stack_outputs import (
@@ -342,7 +343,7 @@ def run_dev(env: str, show_unchanged: bool = False) -> None:
     console.print("Running local dev server now...")
 
     run_bridge_server(
-        region=context().aws.region,
+        region=ProviderStore.region(),
         profile=context().aws.profile,
         app_name=context().name,
         env=env,

--- a/stelvio/command_run.py
+++ b/stelvio/command_run.py
@@ -142,7 +142,7 @@ def _setup_app_home_storage(env: str, dev_mode: bool = False) -> tuple[Home, App
     _load_stlv_app(env, dev_mode)
     ctx = context()
     if ctx.home == "aws":
-        home: Home = AwsHome(ctx.aws.profile, ctx.aws.region)
+        home: Home = AwsHome(ctx.aws.profile, ProviderStore.region())
     else:
         raise ValueError(f"Unknown home type: {ctx.home}")
     _init_storage(home)
@@ -270,9 +270,10 @@ def _create_stack(ctx: AppContext, passphrase: str, workdir: Path) -> Stack:
     backend = ProjectBackend(f"file://{workdir}")
     project_settings = ProjectSettings(name=ctx.name, runtime="python", backend=backend)
     logger.debug("Setting up workspace")
-    env_vars = {"PULUMI_CONFIG_PASSPHRASE": passphrase}
-    if region := ctx.aws.region:
-        env_vars["AWS_REGION"] = region
+    env_vars = {
+        "PULUMI_CONFIG_PASSPHRASE": passphrase,
+        "AWS_REGION": ProviderStore.region(),
+    }
     if profile := ctx.aws.profile:
         env_vars["AWS_PROFILE"] = profile
     opts = LocalWorkspaceOptions(

--- a/stelvio/provider.py
+++ b/stelvio/provider.py
@@ -7,11 +7,20 @@ instead of relying on the implicit default provider.
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, ClassVar
 
+import boto3
 import pulumi_aws
 
+from stelvio.exceptions import StelvioValidationError
+
 if TYPE_CHECKING:
+    from typing import Any
+
+    import pulumi
+
+    from stelvio.component import Component
     from stelvio.context import AppContext
 
 
@@ -31,6 +40,40 @@ class ProviderStore:
     _aws: ClassVar[pulumi_aws.Provider | None] = None
     _regional_aws: ClassVar[dict[str, pulumi_aws.Provider]] = {}
     _context_key: ClassVar[_ContextKey | None] = None
+    _region: ClassVar[str | None] = None
+
+    @classmethod
+    def region(cls) -> str:
+        """Get the app's default AWS region — the one the main provider uses.
+
+        The user's `AwsConfig.region` override if set, otherwise resolved via the
+        standard AWS chain (AWS_REGION, AWS_DEFAULT_REGION, profile config). Every
+        provider is created from this resolved value, so the two cannot diverge.
+        """
+        ctx = cls._get_context()
+        cls._reset_if_context_changed(ctx)
+        if cls._region is None:
+            cls._region = cls._resolve_region(ctx)
+        return cls._region
+
+    @staticmethod
+    def _resolve_region(ctx: AppContext) -> str:
+        if ctx.aws.region:
+            return ctx.aws.region
+        # boto3 ignores AWS_REGION (boto/boto3#3620) but the Pulumi AWS provider —
+        # and our docs — honor it, so check it explicitly before the boto3 chain
+        # (AWS_DEFAULT_REGION, profile config files).
+        region = (
+            os.environ.get("AWS_REGION") or boto3.Session(profile_name=ctx.aws.profile).region_name
+        )
+        if not region:
+            profile_hint = f" (profile: {ctx.aws.profile!r})" if ctx.aws.profile else ""
+            raise StelvioValidationError(
+                f"No AWS region configured{profile_hint}. Set one via "
+                "AwsConfig(region=...) in @app.config, the AWS_REGION environment "
+                "variable, or your AWS profile."
+            )
+        return region
 
     @classmethod
     def aws(cls) -> pulumi_aws.Provider:
@@ -51,7 +94,7 @@ class ProviderStore:
         """
         ctx = cls._get_context()
         cls._reset_if_context_changed(ctx)
-        if region == ctx.aws.region:
+        if region == cls.region():
             if cls._aws is None:
                 cls._aws = cls._create_aws_provider("stelvio-aws", ctx)
             return cls._aws
@@ -62,11 +105,26 @@ class ProviderStore:
         return cls._regional_aws[region]
 
     @classmethod
+    def region_of(cls, provider: pulumi.ProviderResource) -> str:
+        """Plain-str region of a provider created by this store.
+
+        Reading `region` off the provider object would give an Output; the store
+        created every provider from a known region, so it can answer directly.
+        """
+        if provider is cls._aws:
+            return cls.region()
+        for region, regional in cls._regional_aws.items():
+            if regional is provider:
+                return region
+        raise ValueError("Provider was not created by ProviderStore")
+
+    @classmethod
     def reset(cls) -> None:
         """Clear all providers. Used for testing."""
         cls._aws = None
         cls._regional_aws = {}
         cls._context_key = None
+        cls._region = None
 
     @classmethod
     def _reset_if_context_changed(cls, ctx: AppContext) -> None:
@@ -115,7 +173,12 @@ class ProviderStore:
         }
         return pulumi_aws.Provider(
             name,
-            region=region_override or ctx.aws.region,
+            region=region_override or cls.region(),
             profile=ctx.aws.profile,
             default_tags=pulumi_aws.ProviderDefaultTagsArgs(tags=all_tags),
         )
+
+
+def aws_region_of(component: Component[Any, Any]) -> str:
+    """Plain-str region the component's AWS provider deploys to."""
+    return ProviderStore.region_of(component._provider)  # noqa: SLF001

--- a/stelvio/provider.py
+++ b/stelvio/provider.py
@@ -70,8 +70,8 @@ class ProviderStore:
             profile_hint = f" (profile: {ctx.aws.profile!r})" if ctx.aws.profile else ""
             raise StelvioValidationError(
                 f"No AWS region configured{profile_hint}. Set one via "
-                "AwsConfig(region=...) in @app.config, the AWS_REGION environment "
-                "variable, or your AWS profile."
+                "AwsConfig(region=...) in @app.config, the AWS_REGION or "
+                "AWS_DEFAULT_REGION environment variable, or your AWS profile."
             )
         return region
 

--- a/tests/aws/api_gateway/http_api/test_http_api.py
+++ b/tests/aws/api_gateway/http_api/test_http_api.py
@@ -16,8 +16,6 @@ from stelvio.aws.api_gateway.rest_api.constants import (
 )
 from stelvio.aws.cors import CorsConfig
 from stelvio.aws.function import Function, FunctionConfig
-from stelvio.config import AwsConfig
-from stelvio.context import AppContext, _ContextStore
 from tests.test_utils import assert_config_dict_matches_dataclass
 
 from ...pulumi_mocks import ACCOUNT_ID, DEFAULT_REGION, R, tid, tn
@@ -644,30 +642,19 @@ def test_http_api_url_default_stage_execute_api(pulumi_mocks):
 
 
 @pulumi.runtime.test
-def test_http_api_url_uses_resolved_stage_invoke_url_when_config_region_unset(pulumi_mocks):
-    # Save the autouse app_context so we can restore it after temporarily swapping
-    # in a context with an unset region (would otherwise leak into sibling tests).
-    saved = _ContextStore.get()
-    try:
-        _ContextStore.clear()
-        _ContextStore.set(
-            AppContext(
-                name="test",
-                env="test",
-                aws=AwsConfig(),
-                home="aws",
-            )
-        )
-        api = HttpApi("my-api")
-        api.route("GET", "/users", "functions/simple.handler")
+def test_http_api_url_uses_resolved_stage_invoke_url_when_config_region_unset(
+    pulumi_mocks, no_region_context
+):
+    # Region unset in config; the fixture's chain resolves eu-central-1, but the mock
+    # stamps us-east-1 into the stage's invokeUrl output — so this assert passes only
+    # if the URL comes from the stage output, not from a hand-built region string.
+    api = HttpApi("my-api")
+    api.route("GET", "/users", "functions/simple.handler")
 
-        def check(url):
-            assert url == f"https://{HTTP_API_ID}.execute-api.us-east-1.amazonaws.com"
+    def check(url):
+        assert url == f"https://{HTTP_API_ID}.execute-api.us-east-1.amazonaws.com"
 
-        api.url.apply(check)
-    finally:
-        _ContextStore.clear()
-        _ContextStore.set(saved)
+    api.url.apply(check)
 
 
 @pulumi.runtime.test

--- a/tests/aws/api_gateway/http_api/test_http_api_authorizers.py
+++ b/tests/aws/api_gateway/http_api/test_http_api_authorizers.py
@@ -512,6 +512,38 @@ def test_cognito_authorizer_creates_jwt_authorizer(pulumi_mocks):
     when_http_api_ready(api, check)
 
 
+@pulumi.runtime.test
+def test_cognito_authorizer_issuer_uses_resolved_region(pulumi_mocks, no_region_context):
+    """Issuer carries the chain-resolved region when config has none.
+
+    Scenario (the default new-user setup): no `region=` in @app.config, but the AWS
+    chain resolves one (here AWS_REGION=eu-central-1 via the fixture) — so Stelvio
+    deploys fine. The original bug interpolated the raw config value (None) into
+    "https://cognito-idp.None.amazonaws.com/..." — deployed clean, rejected every
+    token at runtime.
+    """
+    pool = UserPool("users", usernames=["email"])
+    client = pool.add_client("web")
+    api = HttpApi("my-api")
+    auth = api.add_cognito_authorizer(
+        "my-cognito",
+        user_pool=pool,
+        audiences=[client],
+    )
+    api.route("GET", "/secure", "functions/simple.handler", auth=auth)
+    _ = api.resources
+
+    def check(_):
+        assert_jwt_authorizer(
+            pulumi_mocks,
+            name="my-cognito",
+            issuer="https://cognito-idp.eu-central-1.amazonaws.com/" + tid(TP + "users"),
+            audiences=[tid(TP + "users-web")],
+        )
+
+    when_http_api_ready(api, check)
+
+
 def test_cognito_authorizer_rejects_client_from_different_pool(pulumi_mocks):
     pool = UserPool("users", usernames=["email"])
     other_pool = UserPool("other-users", usernames=["email"])

--- a/tests/aws/api_gateway/websocket_api/test_websocket_api.py
+++ b/tests/aws/api_gateway/websocket_api/test_websocket_api.py
@@ -529,6 +529,21 @@ def test_websocket_api_url_uses_context_aws_region(pulumi_mocks):
         _ContextStore.set(saved)
 
 
+@pulumi.runtime.test
+def test_websocket_api_url_uses_resolved_region_when_config_region_unset(
+    pulumi_mocks, no_region_context
+):
+    # No region in config; the fixture's chain resolves eu-central-1. The URL is built
+    # from a region string, so a raw config read would render ".execute-api.None.".
+    api = WebsocketApi("chat")
+    api.route("$connect", "functions/simple.handler")
+
+    def check(url):
+        assert url == f"wss://{WEBSOCKET_API_ID}.execute-api.eu-central-1.amazonaws.com/$default"
+
+    api.url.apply(check)
+
+
 @mark.parametrize(
     ("kwargs", "expected_url"),
     [
@@ -557,6 +572,22 @@ def test_websocket_api_management_url_is_https_execute_api(pulumi_mocks, kwargs,
 
     def check(resolved):
         assert resolved == expected_url
+
+    management_url.apply(check)
+
+
+@pulumi.runtime.test
+def test_websocket_api_management_url_uses_resolved_region_when_config_region_unset(
+    pulumi_mocks, no_region_context
+):
+    api = WebsocketApi("chat")
+    management_url = api.management_url
+    api.route("$connect", "functions/simple.handler")
+
+    def check(resolved):
+        assert resolved == (
+            f"https://{WEBSOCKET_API_ID}.execute-api.eu-central-1.amazonaws.com/$default"
+        )
 
     management_url.apply(check)
 

--- a/tests/aws/api_gateway/websocket_api/test_websocket_api.py
+++ b/tests/aws/api_gateway/websocket_api/test_websocket_api.py
@@ -580,6 +580,7 @@ def test_websocket_api_management_url_is_https_execute_api(pulumi_mocks, kwargs,
 def test_websocket_api_management_url_uses_resolved_region_when_config_region_unset(
     pulumi_mocks, no_region_context
 ):
+    # Same trap as the url test above: built from a region string, not a stage output.
     api = WebsocketApi("chat")
     management_url = api.management_url
     api.route("$connect", "functions/simple.handler")

--- a/tests/aws/appsync/test_appsync_data_sources.py
+++ b/tests/aws/appsync/test_appsync_data_sources.py
@@ -75,6 +75,28 @@ def test_data_source_creates_correct_type(
 
 
 @pulumi.runtime.test
+def test_dynamo_data_source_region_uses_resolved_region(
+    pulumi_mocks, project_cwd, no_region_context
+):
+    """dynamodbConfig.region carries the table's chain-resolved region when config has none.
+
+    Scenario (the default new-user setup): no `region=` in @app.config, but the AWS
+    chain resolves one (here AWS_REGION=eu-central-1 via the fixture). The original
+    code sent the raw config value (None); the field means "region of the TABLE",
+    so it now reads the table component's provider region.
+    """
+    api = make_api()
+    ds = make_data_source(api, "dynamo")
+    add_resolver_for_ds(api, ds, "dynamo")
+
+    def check_resources(_):
+        ds_inputs = assert_data_source_inputs(pulumi_mocks, ds_type=DS_TYPE_DYNAMO, name="items")
+        assert ds_inputs["dynamodbConfig"]["region"] == "eu-central-1"
+
+    when_appsync_ready(api, check_resources)
+
+
+@pulumi.runtime.test
 def test_lambda_data_source_creates_function_role_and_accessible(pulumi_mocks, project_cwd):
     api = make_api()
     posts = api.data_source_lambda("posts", handler="functions/simple.handler")

--- a/tests/aws/cloudfront/test_cloudfront_adapter_api_gateway.py
+++ b/tests/aws/cloudfront/test_cloudfront_adapter_api_gateway.py
@@ -8,7 +8,7 @@ from stelvio.aws.cloudfront.origins.components.api_gateway import ApiGatewayClou
 from stelvio.aws.cloudfront.router import Router
 
 from ...conftest import TP
-from ..pulumi_mocks import ACCOUNT_ID, tid, tn
+from ..pulumi_mocks import ACCOUNT_ID, R, tid, tn
 
 
 def test_match_api_component():
@@ -89,5 +89,32 @@ def test_router_creates_cloudfront_origin_for_rest_api(
 
         oacs = pulumi_mocks.created_origin_access_controls()
         assert len(oacs) == 0
+
+    resources.distribution.id.apply(check)
+
+
+@pulumi.runtime.test
+def test_rest_api_origin_domain_uses_resolved_region(
+    pulumi_mocks, mock_get_or_install_dependencies_function, project_cwd, no_region_context
+):
+    """Origin domain carries the chain-resolved region when config has none.
+
+    Scenario (the default new-user setup): no `region=` in @app.config, but the AWS
+    chain resolves one (here AWS_REGION=eu-central-1 via the fixture). The original
+    code asked the DEFAULT provider via a get_region() invoke — not this API's
+    provider — the wrong answer under any future multi-region setup.
+    """
+    api = RestApi("edge-api")
+    api.route("GET", "/users", "functions/simple.handler")
+
+    router = Router("rest-router")
+    router.route("/api", api)
+    resources = router.resources
+
+    def check(_):
+        distribution = pulumi_mocks.assert_res("rest-router", R.DISTRIBUTION)
+        assert distribution.inputs["origins"][0]["domainName"] == (
+            f"{tid(TP + 'edge-api')}.execute-api.eu-central-1.amazonaws.com"
+        )
 
     resources.distribution.id.apply(check)

--- a/tests/aws/cloudfront/test_cloudfront_adapter_http_api.py
+++ b/tests/aws/cloudfront/test_cloudfront_adapter_http_api.py
@@ -100,7 +100,7 @@ def test_http_api_origin_domain_uses_resolved_region(
     router.route("/api", api)
     resources = router.resources
 
-    api_id = tid(TP + "edge-api")[:8]
+    api_id = tid(TP + "edge-api")
 
     def check(_):
         distribution = pulumi_mocks.assert_res("http-router", R.DISTRIBUTION)

--- a/tests/aws/cloudfront/test_cloudfront_adapter_http_api.py
+++ b/tests/aws/cloudfront/test_cloudfront_adapter_http_api.py
@@ -82,6 +82,35 @@ def test_router_creates_cloudfront_origin_for_http_api(
     resources.distribution.id.apply(check)
 
 
+@pulumi.runtime.test
+def test_http_api_origin_domain_uses_resolved_region(
+    pulumi_mocks, mock_get_or_install_dependencies_function, project_cwd, no_region_context
+):
+    """Origin domain carries the chain-resolved region when config has none.
+
+    Scenario (the default new-user setup): no `region=` in @app.config, but the AWS
+    chain resolves one (here AWS_REGION=eu-central-1 via the fixture). The original
+    bug interpolated the raw config value (None) into
+    "<id>.execute-api.None.amazonaws.com" — CloudFront pointed at a dead host.
+    """
+    api = HttpApi("edge-api")
+    api.route("GET", "/users", "functions/simple.handler")
+
+    router = Router("http-router")
+    router.route("/api", api)
+    resources = router.resources
+
+    api_id = tid(TP + "edge-api")[:8]
+
+    def check(_):
+        distribution = pulumi_mocks.assert_res("http-router", R.DISTRIBUTION)
+        assert distribution.inputs["origins"][0]["domainName"] == (
+            f"{api_id}.execute-api.eu-central-1.amazonaws.com"
+        )
+
+    resources.distribution.id.apply(check)
+
+
 @mark.parametrize(
     "case",
     [

--- a/tests/aws/cognito/test_identity_pool.py
+++ b/tests/aws/cognito/test_identity_pool.py
@@ -15,7 +15,7 @@ from stelvio.aws.cognito.user_pool import UserPool
 from stelvio.aws.permission import AwsPermission
 
 from ...conftest import TP
-from ..pulumi_mocks import ACCOUNT_ID, tid, tn
+from ..pulumi_mocks import ACCOUNT_ID, R, tid, tn
 
 # =========================================================================
 # Config validation tests (no Pulumi mocks needed)
@@ -196,6 +196,33 @@ def test_cognito_identity_providers(pulumi_mocks):
         assert "clientId" in provider
         assert "providerName" in provider
         assert provider["serverSideTokenCheck"] is False
+
+    identity.authenticated_role_arn.apply(check)
+
+
+@pulumi.runtime.test
+def test_identity_provider_name_uses_resolved_region(pulumi_mocks, no_region_context):
+    """Provider name carries the chain-resolved region when config has none.
+
+    Scenario (the default new-user setup): no `region=` in @app.config, but the AWS
+    chain resolves one (here AWS_REGION=eu-central-1 via the fixture) — so Stelvio
+    deploys fine. The issuer string must use that resolved region. The original bug
+    interpolated the raw config value (None) into
+    "cognito-idp.None.amazonaws.com/..." → hard deploy failure.
+    """
+    pool = UserPool("users", usernames=["email"])
+    client = pool.add_client("web")
+
+    identity = IdentityPool(
+        "app-identity",
+        user_pools=[IdentityPoolBinding(user_pool=pool, client=client)],
+    )
+
+    def check(_):
+        mock = pulumi_mocks.assert_res("app-identity", R.IDENTITY_POOL)
+        provider = mock.inputs["cognitoIdentityProviders"][0]
+        pool_id = tid(TP + "users")
+        assert provider["providerName"] == f"cognito-idp.eu-central-1.amazonaws.com/{pool_id}"
 
     identity.authenticated_role_arn.apply(check)
 

--- a/tests/aws/function/test_function.py
+++ b/tests/aws/function/test_function.py
@@ -873,6 +873,61 @@ def test_function_dev_mode__(
 
 
 @pulumi.runtime.test
+def test_function_dev_mode_discovers_bridge_in_default_region(
+    project_cwd, pulumi_mocks, no_region_context
+):
+    """Bridge AppSync discovery uses the chain-resolved default region — with no region
+    configured (the default new-user setup), the raw context region would be None."""
+    from stelvio.bridge.remote.infrastructure import AppSyncResource
+    from stelvio.config import AwsConfig
+    from stelvio.context import AppContext, _ContextStore
+
+    # no_region_context's context, but with dev_mode on
+    _ContextStore.clear()
+    _ContextStore.set(
+        AppContext(name="test", env="test", aws=AwsConfig(), home="aws", dev_mode=True)
+    )
+
+    with (
+        patch("stelvio.aws.function.function.discover_or_create_appsync") as mock_discover,
+        patch(
+            "stelvio.aws.function.function._create_lambda_bridge_archive"
+        ) as mock_bridge_archive,
+    ):
+        mock_discover.return_value = AppSyncResource(
+            api_id="test-api-id",
+            http_endpoint="https://test-http.appsync.amazonaws.com",
+            realtime_endpoint="wss://test-realtime.appsync.amazonaws.com",
+            api_key="test-api-key-123",
+        )
+        mock_bridge_archive.return_value = AssetArchive(
+            {"stlv_function_stub.py": StringAsset("stub-content")}
+        )
+
+        _ = Function("test-function", handler="functions/simple.handler").resources
+
+        mock_discover.assert_called_once_with(region="eu-central-1", profile=None)
+
+
+@pulumi.runtime.test
+def test_bridge_event_env_always_injects_function_region(
+    project_cwd, pulumi_mocks, no_region_context
+):
+    """PRIVATE-HELPER test (behavior not observable via Pulumi resources): the local
+    bridge event env always carries the function's region — emulating the Lambda
+    runtime — even when no region is configured (it used to skip injection then)."""
+    function = Function("test-function", handler="functions/simple.handler")
+
+    async def check():
+        env = await function._get_environment_for_bridge_event()
+        assert env["AWS_REGION"] == "eu-central-1"
+        assert env["AWS_DEFAULT_REGION"] == "eu-central-1"
+        assert "AWS_PROFILE" not in env
+
+    return check()
+
+
+@pulumi.runtime.test
 def test_function_dev_mode_registers_handler(project_cwd, pulumi_mocks):
     """Test that function registers itself with WebsocketHandlers in bridge mode."""
     from stelvio.bridge.local.handlers import WebsocketHandlers

--- a/tests/aws/pulumi_mocks.py
+++ b/tests/aws/pulumi_mocks.py
@@ -391,14 +391,11 @@ class PulumiTestMocks(Mocks):
                 "arn": f"arn:aws:iam::{ACCOUNT_ID}:user/{TEST_USER}",
                 "userId": f"{TEST_USER}-id",
             }, []
-        if args.token == "aws:index/getRegion:getRegion":  # noqa: S105
-            return {
-                "name": "us-east-1",
-                "region": "us-east-1",
-                "description": "US East (N. Virginia)",
-            }, []
         if args.token == "aws:index/getAvailabilityZones:getAvailabilityZones":  # noqa: S105
-            return {"names": ["us-east-1a", "us-east-1b", "us-east-1c"]}, []
+            # Like real AWS: the answer is scoped to the requested region, so tests
+            # can observe which region the caller asked about through the AZ names.
+            region = args.args.get("region") or DEFAULT_REGION
+            return {"names": [f"{region}a", f"{region}b", f"{region}c"]}, []
 
         return {}, []
 

--- a/tests/aws/test_vpc.py
+++ b/tests/aws/test_vpc.py
@@ -127,6 +127,26 @@ def test_vpc_deploy_raises_value_error_when_az_unavailable(pulumi_mocks, az, err
         deploy()
 
 
+def test_vpc_az_lookup_uses_resolved_region(pulumi_mocks, no_region_context):
+    """Subnets land in the chain-resolved region's AZs when config has none.
+
+    Scenario (the default new-user setup): no `region=` in @app.config, but the AWS
+    chain resolves one (here AWS_REGION=eu-central-1 via the fixture). The original
+    code asked the DEFAULT provider for AZs (and get_region() for messages); now the
+    AZ lookup is scoped to the Vpc's own region — the mock answers with AZ names
+    derived from the requested region, so the names below prove which region was asked.
+    """
+
+    @pulumi.runtime.test
+    def deploy():
+        return Vpc("main_vpc", az=2).resources
+
+    deploy()
+
+    subnets = pulumi_mocks.created(R.SUBNET)
+    assert {s.inputs["availabilityZone"] for s in subnets} == {"eu-central-1a", "eu-central-1b"}
+
+
 @dataclass
 class VpcTestCase:
     """A vpc config and the complete infrastructure expected from it.

--- a/tests/bridge/test_dev_infra.py
+++ b/tests/bridge/test_dev_infra.py
@@ -113,28 +113,6 @@ def test_discover_or_create_appsync_with_profile():
         assert result == mock_resource
 
 
-def test_discover_or_create_appsync_default_region():
-    """Test discover_or_create_appsync with default region."""
-    mock_client = MagicMock()
-    mock_resource = TEST_APPSYNC_RESOURCE
-
-    with (
-        patch("stelvio.bridge.remote.infrastructure.boto3.Session") as mock_session,
-        patch(
-            "stelvio.bridge.remote.infrastructure.find_or_create_appsync_api"
-        ) as mock_find_create,
-    ):
-        mock_session_instance = MagicMock()
-        mock_session.return_value = mock_session_instance
-        mock_session_instance.client.return_value = mock_client
-        mock_find_create.return_value = mock_resource
-
-        result = discover_or_create_appsync()
-
-        mock_session.assert_called_once_with(profile_name=None, region_name="us-east-1")
-        assert result == mock_resource
-
-
 def test_find_or_create_appsync_api_found():
     """Test finding an existing AppSync API."""
     mock_client = MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,30 @@ def app_context():
 
 
 @pytest.fixture
+def no_region_context(app_context, monkeypatch, tmp_path):
+    """Context with NO region configured in Stelvio; the AWS chain resolves eu-central-1.
+
+    Depends on `app_context` so it explicitly runs after (and replaces) the autouse
+    default context rather than relying on fixture instantiation order.
+
+    Reproduces the default new-user setup (bare AwsConfig()) that every hardcoded
+    region="us-east-1" test context hides. No mocking: the real boto3 chain runs and
+    picks the region up from AWS_REGION, pinned here for determinism. The machine's
+    ~/.aws files are redirected to nonexistent paths so they can never leak in —
+    tests stay hermetic even if the chain order changes.
+    """
+    _ContextStore.clear()
+    _ContextStore.set(
+        AppContext(name="test", env="test", aws=AwsConfig(), home="aws", customize={})
+    )
+    monkeypatch.setenv("AWS_REGION", "eu-central-1")
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "missing-config"))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "missing-credentials"))
+
+
+@pytest.fixture
 def pulumi_mocks():
     mocks = PulumiTestMocks()
     set_mocks(mocks)

--- a/tests/integration/run_all.sh
+++ b/tests/integration/run_all.sh
@@ -4,7 +4,7 @@
 # This file is the single source of truth for test/worker counts. Counts are
 # chosen so tests divide evenly across workers with no straggler left running
 # alone at the end. Adjust when adding/removing tests:
-#   integration    — 183 tests / 10 workers
+#   integration    — 184 tests / 10 workers
 #   integration_cf —  14 tests /  7 workers
 #   integration_dns—  10 tests /  3 workers
 #

--- a/tests/integration/test_provider.py
+++ b/tests/integration/test_provider.py
@@ -3,12 +3,19 @@
 import pytest
 
 from stelvio.app import StelvioApp
+from stelvio.aws.cognito import IdentityPool, UserPool
+from stelvio.aws.cognito.types import IdentityPoolBinding
 from stelvio.aws.dynamo_db import DynamoTable
 from stelvio.aws.queue import Queue
 from stelvio.config import AwsConfig, StelvioAppConfig
 
-from .assert_helpers import assert_dynamo_tags, assert_sqs_tags
-from .export_helpers import export_dynamo_table, export_queue
+from .assert_helpers import assert_cognito_identity_pool, assert_dynamo_tags, assert_sqs_tags
+from .export_helpers import (
+    export_dynamo_table,
+    export_identity_pool,
+    export_queue,
+    export_user_pool,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -113,6 +120,52 @@ def test_component_tags_override_global_tags(stelvio_env):
             "GlobalOnly": "yes",
         },
     )
+
+
+def test_region_resolved_from_chain_when_not_configured(stelvio_env, monkeypatch):
+    """With no region in AwsConfig, the region resolves via AWS_REGION and flows into
+    region-derived strings.
+
+    Regression: 0.9.0b5 interpolated a literal 'None' into IdentityPool provider names
+    when region wasn't configured — and boto3 alone ignores AWS_REGION (boto/boto3#3620),
+    so only-AWS_REGION setups broke even where the Pulumi provider resolved correctly.
+    """
+    monkeypatch.setenv("AWS_REGION", stelvio_env.aws_region)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+
+    app = StelvioApp(f"stlv-{stelvio_env.run_id}")
+
+    @app.config
+    def config(stage):
+        return StelvioAppConfig(
+            aws=AwsConfig(profile=stelvio_env.aws_profile),  # region deliberately unset
+        )
+
+    @app.run
+    def run():
+        pool = UserPool("auth", usernames=["email"])
+        web = pool.add_client("web")
+        identity = IdentityPool(
+            "main",
+            user_pools=[IdentityPoolBinding(user_pool=pool, client=web)],
+        )
+        export_user_pool(pool)
+        export_identity_pool(identity)
+
+    outputs = stelvio_env.deploy_app(app)
+
+    # The provider name is the exact string that contained 'None' before the fix
+    region = stelvio_env.aws_region
+    pool_id = outputs["user_pool_auth_id"]
+    assert_cognito_identity_pool(
+        outputs["identity_pool_main_id"],
+        expected_provider_names=[f"cognito-idp.{region}.amazonaws.com/{pool_id}"],
+    )
+
+    # The provider itself was created with the resolved region as an explicit input
+    resources = stelvio_env.export_resources()
+    provider = _find_by_type(resources, "pulumi:providers:aws")
+    assert provider["inputs"].get("region") == region
 
 
 def test_component_hierarchy(stelvio_env):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,11 +1,98 @@
 import json
 
 import pulumi
+import pulumi_aws
+from pytest import raises
 
+from stelvio.aws import default_region
 from stelvio.aws.topic import Topic
 from stelvio.config import AwsConfig
 from stelvio.context import AppContext, _ContextStore
+from stelvio.exceptions import StelvioValidationError
 from stelvio.provider import ProviderStore
+
+# --- Region resolution ---
+
+
+def test_default_region_falls_back_to_aws_chain(no_region_context):
+    """With no region configured, the region resolves via the standard AWS chain."""
+    assert default_region() == "eu-central-1"
+
+
+def test_default_region_prefers_aws_region_over_aws_default_region(no_region_context, monkeypatch):
+    """AWS_REGION wins over AWS_DEFAULT_REGION — pins the explicit env check that works
+    around boto3 reading only AWS_DEFAULT_REGION (boto/boto3#3620)."""
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-3")
+    assert default_region() == "eu-central-1"
+
+
+def test_default_region_falls_back_to_boto3_chain(no_region_context, monkeypatch):
+    """AWS_DEFAULT_REGION resolves too — via boto3, which ignores AWS_REGION (boto/boto3#3620)."""
+    monkeypatch.delenv("AWS_REGION")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-3")
+    assert default_region() == "eu-west-3"
+
+
+def test_default_region_config_override_wins(monkeypatch):
+    """AwsConfig(region=...) beats whatever the AWS chain would resolve."""
+    monkeypatch.setenv("AWS_REGION", "eu-central-1")
+    assert default_region() == "us-east-1"  # from the default test context
+
+
+def test_default_region_unresolvable_raises_friendly_error(no_region_context, monkeypatch):
+    """Nothing configured anywhere: a friendly error, not a silent us-east-1 or a traceback."""
+    monkeypatch.delenv("AWS_REGION")
+    with raises(StelvioValidationError, match="No AWS region configured"):
+        default_region()
+
+
+@pulumi.runtime.test
+def test_aws_provider_created_with_resolved_region(pulumi_mocks, no_region_context):
+    """The provider gets the chain-resolved region explicitly — never an unset region."""
+    provider = ProviderStore.aws()
+
+    def check(_):
+        pulumi_mocks.assert_res(
+            "stelvio-aws", inputs={"region": "eu-central-1"}, partial=True, prefixed=False
+        )
+
+    provider.region.apply(check)
+
+
+@pulumi.runtime.test
+def test_aws_for_region_returns_default_when_matches_resolved_region(
+    pulumi_mocks, no_region_context
+):
+    """With no configured region, aws_for_region(resolved) still reuses the main provider."""
+    default = ProviderStore.aws()
+    regional = ProviderStore.aws_for_region("eu-central-1")
+    assert default is regional
+
+
+# --- Region of a provider / component ---
+# pulumi_mocks isn't asserted on here — Provider objects are Pulumi resources, and
+# creating one in-process needs mocks registered. "us-east-1" is the region the autouse
+# app_context fixture configures for every test.
+
+
+@pulumi.runtime.test
+def test_region_of_answers_for_store_providers(pulumi_mocks):
+    """region_of answers plainly for the main and any regional provider.
+
+    The regional branch has no component using it yet (components all deploy through
+    the main provider) — it's the multi-region seam, so it's pinned directly here.
+    """
+    assert ProviderStore.region_of(ProviderStore.aws()) == "us-east-1"
+    assert ProviderStore.region_of(ProviderStore.aws_for_region("eu-west-1")) == "eu-west-1"
+
+
+@pulumi.runtime.test
+def test_region_of_foreign_provider_raises(pulumi_mocks):
+    """A provider the store didn't create fails loudly instead of guessing a region."""
+    foreign = pulumi_aws.Provider("foreign")
+    with raises(ValueError, match="not created by ProviderStore"):
+        ProviderStore.region_of(foreign)
+
 
 # --- Provider creation and configuration ---
 


### PR DESCRIPTION
With no `region` in `@app.config`, components that build region-based strings got a literal `None` — a hard deploy failure for `IdentityPool` (invalid provider name) and broken region values in AppSync DynamoDB data sources and CloudFront API origins. The region now resolves once via the standard AWS chain (`AWS_REGION` checked explicitly since boto3 ignores it, then `AWS_DEFAULT_REGION`/profile config); every provider is created with the resolved region, sites read their component's provider region via `aws_region_of()`, and an unresolvable region fails fast with a clear message. Adds unit coverage plus an integration test for the previously untested no-region path; verified live end-to-end (upgrade diff from an old-code stack shows zero updates/replacements).

Rebased on #264/#266. `WebsocketApi.url`/`management_url` read `context().aws.region` directly (rendering `execute-api.None` with no region configured) and now go through `aws_region_of()`, with no-region tests for both. `AcmValidatedDomain` picks its cross-region provider via `ProviderStore.aws_for_region()` alone; the old compare against the raw config region was redundant, since `aws_for_region` already returns the main provider on a match. The http_api test gate from this branch was dropped for the one #266 landed on main, which also covers owned `domain_name=` domains.